### PR TITLE
Fix spawn pose of the robot

### DIFF
--- a/irobot_create_description/urdf/create3.urdf.xacro
+++ b/irobot_create_description/urdf/create3.urdf.xacro
@@ -31,7 +31,7 @@
   <link name="base_footprint"/>
 
   <joint name="base_footprint_joint" type="fixed">
-    <origin xyz="0 0 0.065594" rpy="0 0.012796 0"/>
+    <origin xyz="0 0 0.066" rpy="0 0.013 0"/>
     <parent link="base_footprint"/>
     <child link="base_link" />
   </joint>


### PR DESCRIPTION
## Description

This PR fixes the spawn pose of the robot. Right now, the robot gets spawned below the ground plane, "jumping" onto a stable position right after gazebo starts.

![image](https://user-images.githubusercontent.com/5348967/127713857-cea7dc22-7f25-4fad-886d-5bd60fb80b54.png)

With these changes, the robot now spawns at the correct position:
![Screenshot from 2021-07-30 17-37-23](https://user-images.githubusercontent.com/5348967/127713948-3a995562-6240-41b0-a537-f921fcfe0177.png)

Fixes https://trello.com/c/xXRmPkOt

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Just spawn the robot in an empty environment and inspect it visually:
```bash
# Run this command
ros2 launch irobot_create_gazebo create3.launch.py
```

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
