### PR TITLE
Rename wheel drop plugin arguments to be camel_cased

### DIFF
--- a/irobot_create_description/urdf/wheel_drop.urdf.xacro
+++ b/irobot_create_description/urdf/wheel_drop.urdf.xacro
@@ -39,10 +39,10 @@
         <namespace>wheel_drop</namespace>
         <remapping>~/out:=${name}_wheel/event</remapping>
       </ros>
-      <updateRate>${update_rate}</updateRate>
-      <detectionThreshold>${detection_threshold_cm*cm2m}</detectionThreshold>
-      <jointName>wheel_${name}_axle_joint</jointName>
-      <frameId>wheel_${name}_axle_link</frameId>
+      <update_rate>${update_rate}</update_rate>
+      <detection_threshold>${detection_threshold_cm*cm2m}</detection_threshold>
+      <joint_name>wheel_${name}_axle_joint</joint_name>
+      <frame_id>wheel_${name}_axle_link</frame_id>
     </plugin>
   </gazebo>
 

--- a/irobot_create_gazebo_plugins/src/gazebo_ros_wheel_drop.cpp
+++ b/irobot_create_gazebo_plugins/src/gazebo_ros_wheel_drop.cpp
@@ -23,10 +23,10 @@ void GazeboRosWheelDrop::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr s
   double update_rate{62.0};
   double detection_threshold{0.7};
   std::string joint_name{""};
-  utils::initialize(update_rate, sdf, "updateRate", 62.0);
-  utils::initialize(detection_threshold, sdf, "detectionThreshold", 0.7);
-  utils::initialize(joint_name, sdf, "jointName", "");
-  utils::initialize(frame_id_, sdf, "frameId", "");
+  utils::initialize(update_rate, sdf, "update_rate", 62.0);
+  utils::initialize(detection_threshold, sdf, "detection_threshold", 0.7);
+  utils::initialize(joint_name, sdf, "joint_name", "");
+  utils::initialize(frame_id_, sdf, "frame_id", "");
 
   world_ = model->GetWorld();
   GZ_ASSERT(world_, "[WHEEL DROP PLUGIN] Invalid world pointer!");


### PR DESCRIPTION
## Description

This PR renames wheel drop plugin arguments to be camel_cased to match with ROS 2 standards.

Fixes https://trello.com/c/mcb8Kwan.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

It just builds in CI.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
