### PR TITLE
Fix state_interface error

### DIFF
--- a/irobot_create_description/urdf/wheel.urdf.xacro
+++ b/irobot_create_description/urdf/wheel.urdf.xacro
@@ -47,6 +47,7 @@
       </hardware>
 
       <joint name="wheel_${name}_joint">
+        <state_interface name="position" />
         <command_interface name="velocity" />
       </joint>
   </ros2_control>


### PR DESCRIPTION
## Description

Fixes error:

`[gzserver-6] [ERROR] [1629242659.284333589] [controller_manager]: Can't activate controller 'diffdrive_controller': State interface with key 'wheel_left_joint/position' does not exist`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

