### PR TITLE
Updates the Prerequisites to work with Create 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This is a [ROS 2](https://docs.ros.org/en/foxy/index.html) simulation stack for 
 
 1. Ros 2 ([foxy](https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html) or [galactic](https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Debians.html)): it's recommended to install the desktop version of the distribution of your choosing, this will also install RViz 2. Bare in mind that if another version is installed, some dependencies may be missing.
 2. [Gazebo](http://gazebosim.org/tutorials?tut=install_ubuntu)
-3. RViz 2: this is included as part of the rosdep dependecies.
+3. [RViz2](https://github.com/ros2/rviz): this is included as part of the rosdep dependecies.
 
 ## Build
 


### PR DESCRIPTION
## Description
Adds Gazebo and RViz as prerequisits to build a Create3 workspace. Links to the installation tutorials for Ros2 (foxy or galactic), Gazebo and RViz were included. 
Fixes #41 .

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
To test this I deleted all the tools needed and re-install them following the step-by-step tutorials from the included links. After that I followed the `build` instructions from the README file and I was able to run a gazebo world and RViz with the Create3 robot.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
