### PR TITLE
Installs launch directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This is a [ROS 2](https://docs.ros.org/en/foxy/index.html) simulation stack for 
 1. Ros 2 ([foxy](https://docs.ros.org/en/foxy/Installation/Ubuntu-Install-Debians.html) or [galactic](https://docs.ros.org/en/galactic/Installation/Ubuntu-Install-Debians.html)): it's recommended to install the desktop version of the distribution of your choosing, this will also install RViz 2. Bare in mind that if another version is installed, some dependencies may be missing.
 2. [Gazebo](http://gazebosim.org/tutorials?tut=install_ubuntu)
 3. [RViz2](https://github.com/ros2/rviz): this is included as part of the rosdep dependecies.
+4. [xterm](https://manpages.ubuntu.com/manpages/xenial/man1/xterm.1.html): Used to teleoperate the robot with the keyboard.
+5. [vcs](https://github.com/dirk-thomas/vcstool): Used to clone extra packages such as the AWS small house environment.
 
 ## Build
 

--- a/irobot_create_toolbox/CMakeLists.txt
+++ b/irobot_create_toolbox/CMakeLists.txt
@@ -57,6 +57,7 @@ target_link_libraries(wheel_status_publisher_node wheel_status_publisher_lib)
 install(
   DIRECTORY
     include
+  DESTINATION include
 )
 
 install(


### PR DESCRIPTION
## Description

It was brought to my attention that the irobot_create_toolbox package contains a launchfile to teleoperate the robot that was not working anymore. I realized that the issue was that the launch directory that contains this launchfile was not being declared in the install instruction in CMakeLists.txt and thus the entire directory was not installed when building the project
Fixes #47 
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Testing this PR is very simple. Before applying this change you shouldn't be able to launch teleport_keyboard.launch.py but that should work after applying the changes in this PR.
```bash
# Run this command
ros2 launch irobot_create_toolbox teleop_keyboard.launch.py
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
