### PR TITLE
Set GAZEBO_MODEL_PATH if not exist for AWS Small house

### DIFF
--- a/irobot_create_gazebo/launch/aws_small.launch.py
+++ b/irobot_create_gazebo/launch/aws_small.launch.py
@@ -45,8 +45,7 @@ def generate_launch_description():
         launch_arguments={'world_path': world_path}.items())
 
     # Add AWS models to gazebo path
-    # On the EnvironmentVariable, I had to set a default_value that is needed
-    # because if not exist the EnvironmentVariable fails
+    # This environment variable needs to be set, otherwise code fails
     set_gazebo_model_path_env = SetEnvironmentVariable(
         name='GAZEBO_MODEL_PATH',
         value=[EnvironmentVariable('GAZEBO_MODEL_PATH', default_value=''), aws_model_path])


### PR DESCRIPTION
## Description
If you don't have defined the environmental variable GAZEBO_MODEL_PATH, you will get this error:

```
Task exception was never retrieved
future: <Task finished name='Task-2' coro=<LaunchService._process_one_event() done, defined at /opt/ros/foxy/lib/python3.8/site-packages/launch/launch_service.py:226> exception=SubstitutionFailure("environment variable 'GAZEBO_MODEL_PATH' does not exist")>
```
Fixes #67 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

```bash
# Run this command 
unset GAZEBO_MODEL_PATH
ros2 launch irobot_create_gazebo aws_small.launch.py

GAZEBO_MODEL_PATH="" ros2 launch irobot_create_gazebo aws_small.launch.py 
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
