### PR TITLE
add colcon and rosdep to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@ This is a [ROS 2](https://docs.ros.org/en/foxy/index.html) simulation stack for 
 2. [Gazebo](http://gazebosim.org/tutorials?tut=install_ubuntu)
 3. [RViz2](https://github.com/ros2/rviz): this is included as part of the rosdep dependecies.
 4. [xterm](https://manpages.ubuntu.com/manpages/xenial/man1/xterm.1.html): Used to teleoperate the robot with the keyboard.
-5. [vcs](https://github.com/dirk-thomas/vcstool): Used to clone extra packages such as the AWS small house environment.
+5. ROS 2 dev tools:
+    - [colcon-common-extensions](https://pypi.org/project/colcon-common-extensions/)
+    - [rosdep](https://pypi.org/project/rosdep/): Used to install dependencies when building from sources
+    - [vcs](https://github.com/dirk-thomas/vcstool): Used to clone extra packages such as the AWS small house environment.
+
 
 ## Build
 


### PR DESCRIPTION
Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>

## Description

Add missing dependencies in README
Installing `ros-galactic-desktop` does not include the dependencies necessary for building packages from sources.