### PR TITLE
docking status publication

### DIFF
--- a/irobot_create_description/urdf/create3.urdf.xacro
+++ b/irobot_create_description/urdf/create3.urdf.xacro
@@ -11,7 +11,7 @@
   <xacro:include filename="$(find irobot_create_description)/urdf/sensors/optical_mouse.urdf.xacro"/>
   <xacro:include filename="$(find irobot_create_description)/urdf/wheel_with_wheeldrop.urdf.xacro" />
 
-  <!-- MECHANICAL PROPERTIES -->
+  <!-- Mechanical properties -->
   <xacro:property name="body_z_offset"           value="${-2.5*cm2m}" />
   <xacro:property name="body_collision_z_offset" value="${1*cm2m}" />
   <xacro:property name="body_mass"               value="2.300" />
@@ -31,6 +31,12 @@
 
   <xacro:property name="wheel_drop_offset_z"     value="${3.5*mm2m}"/>
   <xacro:property name="wheel_drop_z"            value="${wheel_height + wheel_drop_offset_z}"/>
+
+  <!-- Docking properties -->
+  <xacro:property name="robot_model_name" value="create3"/>
+  <xacro:property name="receiver_link_name" value="ir_omni"/>
+  <xacro:property name="dock_model_name" value="standard_dock"/>
+  <xacro:property name="emitter_link_name" value="halo_link"/>
 
   <!-- Create 3 base definition-->
   <origin xyz="0 0 0.064171"/>
@@ -184,9 +190,24 @@
   <!-- Omni IR receiver (sensor 0) parameters and Front-facing IR receiver (sensor 1) parameters -->
   <xacro:property name="ir_omni_fov_rad" value="${220.0*deg2rad}"/>
   <xacro:property name="ir_front_facing_fov_rad" value="${pi/2}"/>
-  <xacro:ir_opcode_receivers sensor_0_range="0.01" sensor_0_fov="${ir_omni_fov_rad}"
+  <xacro:ir_opcode_receivers robot_model_name="${robot_model_name}" dock_model_name="${dock_model_name}" emitter_link_name="${emitter_link_name}" sensor_0_range="0.01" sensor_0_fov="${ir_omni_fov_rad}"
     sensor_1_range="0.5" sensor_1_fov="${ir_front_facing_fov_rad}" visualize="true" >
     <origin xyz="0.153 0 0.035"/>
   </xacro:ir_opcode_receivers>
+
+  <!-- Dock status -->
+  <gazebo>
+    <plugin name="dock_status_publisher" filename="libgazebo_ros_create_docking_status.so">
+      <ros>
+        <namespace>/</namespace>
+        <remapping>~/out:=dock</remapping>
+      </ros>
+      <update_rate>1.0</update_rate>
+      <robot_model_name>${robot_model_name}</robot_model_name>
+      <receiver_link_name>${receiver_link_name}</receiver_link_name>
+      <dock_model_name>${dock_model_name}</dock_model_name>
+      <emitter_link_name>${emitter_link_name}</emitter_link_name>
+    </plugin>
+  </gazebo>
 
 </robot>

--- a/irobot_create_description/urdf/sensors/ir_opcode_receivers.urdf.xacro
+++ b/irobot_create_description/urdf/sensors/ir_opcode_receivers.urdf.xacro
@@ -3,6 +3,9 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:macro name="ir_opcode_receivers" params="name:=ir_omni
+                                                  robot_model_name
+                                                  dock_model_name
+                                                  emitter_link_name
                                                   parent:=base_link
                                                   sensor_0_fov
                                                   sensor_0_range
@@ -15,15 +18,15 @@
                                                   *origin" >
 
     <xacro:property name="joint_name" value="${name}_joint" />
-    <xacro:property name="link_name" value="${name}" />
+    <xacro:property name="receiver_link_name" value="${name}" />
 
     <joint name="${joint_name}" type="fixed">
       <xacro:insert_block name="origin" />
       <parent link="${parent}"/>
-      <child link="${link_name}"/>
+      <child link="${receiver_link_name}"/>
     </joint>
 
-    <link name="${link_name}">
+    <link name="${receiver_link_name}">
       <xacro:inertial_dummy />
     </link>
 
@@ -31,7 +34,7 @@
     This there is no need for high update rates. -->
     <xacro:if value="${visualize}">
       <!-- Sensor 0 visualization -->
-      <gazebo reference="${link_name}">
+      <gazebo reference="${receiver_link_name}">
         <sensor type="ray" name="sensor_0">
             <always_on>true</always_on>
             <update_rate>1</update_rate>
@@ -55,7 +58,7 @@
       </gazebo>
 
       <!-- Sensor 1 visualization -->
-      <gazebo reference="${link_name}">
+      <gazebo reference="${receiver_link_name}">
         <sensor type="ray" name="sensor_1">
             <always_on>true</always_on>
             <update_rate>1</update_rate>
@@ -86,7 +89,10 @@
           <remapping>~/out:=ir_opcode</remapping>
         </ros>
         <update_rate>${update_rate}</update_rate>
-        <link_name>${link_name}</link_name>
+        <robot_model_name>${robot_model_name}</robot_model_name>
+        <receiver_link_name>${receiver_link_name}</receiver_link_name>
+        <dock_model_name>${dock_model_name}</dock_model_name>
+        <emitter_link_name>${emitter_link_name}</emitter_link_name>
         <sensor_0_fov>${sensor_0_fov}</sensor_0_fov>
         <sensor_0_range>${sensor_0_range}</sensor_0_range>
         <sensor_1_fov>${sensor_1_fov}</sensor_1_fov>

--- a/irobot_create_gazebo_plugins/CMakeLists.txt
+++ b/irobot_create_gazebo_plugins/CMakeLists.txt
@@ -29,6 +29,10 @@ add_library(gazebo_ros_create_cliff_sensor SHARED
   src/gazebo_ros_cliff_sensor.cpp
 )
 
+add_library(gazebo_ros_create_docking_status SHARED
+  src/gazebo_ros_docking_status.cpp
+)
+
 add_library(gazebo_ros_create_helpers SHARED
   src/gazebo_ros_helpers.cpp
 )
@@ -58,17 +62,6 @@ add_library(gazebo_ros_create_wheel_drop SHARED
 )
 
 # Linking
-## gazebo_ros_cliff_sensor
-target_include_directories(gazebo_ros_create_cliff_sensor PUBLIC include)
-ament_target_dependencies(gazebo_ros_create_cliff_sensor
-  "gazebo_dev"
-  "gazebo_ros"
-  "irobot_create_msgs"
-  "rclcpp"
-)
-ament_export_libraries(gazebo_ros_create_cliff_sensor)
-target_link_libraries(gazebo_ros_create_cliff_sensor gazebo_ros_create_helpers)
-
 ## gazebo_ros_create_bumper
 target_include_directories(gazebo_ros_create_bumper PUBLIC include)
 ament_target_dependencies(gazebo_ros_create_bumper
@@ -79,6 +72,28 @@ ament_target_dependencies(gazebo_ros_create_bumper
 )
 ament_export_libraries(gazebo_ros_create_bumper)
 target_link_libraries(gazebo_ros_create_bumper gazebo_ros_create_helpers)
+
+## gazebo_ros_create_cliff_sensor
+target_include_directories(gazebo_ros_create_cliff_sensor PUBLIC include)
+ament_target_dependencies(gazebo_ros_create_cliff_sensor
+  "gazebo_dev"
+  "gazebo_ros"
+  "irobot_create_msgs"
+  "rclcpp"
+)
+ament_export_libraries(gazebo_ros_create_cliff_sensor)
+target_link_libraries(gazebo_ros_create_cliff_sensor gazebo_ros_create_helpers)
+
+## gazebo_ros_create_docking_status
+target_include_directories(gazebo_ros_create_docking_status PUBLIC include)
+ament_target_dependencies(gazebo_ros_create_docking_status
+  "gazebo_dev"
+  "gazebo_ros"
+  "irobot_create_msgs"
+  "rclcpp"
+)
+ament_export_libraries(gazebo_ros_create_docking_status)
+target_link_libraries(gazebo_ros_create_docking_status gazebo_ros_create_helpers)
 
 ## gazebo_ros_create_helpers
 target_include_directories(gazebo_ros_create_helpers PUBLIC include)
@@ -166,6 +181,7 @@ install(DIRECTORY include/
 install(TARGETS
     gazebo_ros_create_bumper
     gazebo_ros_create_cliff_sensor
+    gazebo_ros_create_docking_status
     gazebo_ros_create_helpers
     gazebo_ros_create_imu
     gazebo_ros_create_ir_intensity_sensor

--- a/irobot_create_gazebo_plugins/include/irobot_create_gazebo_plugins/docking_manager.hpp
+++ b/irobot_create_gazebo_plugins/include/irobot_create_gazebo_plugins/docking_manager.hpp
@@ -39,9 +39,11 @@ private:
   gazebo::physics::LinkPtr emitter_link_{nullptr};
   // World pointer
   gazebo::physics::WorldPtr world_{nullptr};
-  // Model names
+  // Model and their respective link names
   std::string robot_model_name_;
+  std::string robot_receiver_link_name_;
   std::string dock_model_name_;
+  std::string dock_emitter_link_name_;
 
   // Once models are ready, initialize their link pointers
   void initLinks(
@@ -51,7 +53,8 @@ public:
   /// Constructor
   DockingManager(
     const gazebo::physics::WorldPtr & world, const std::string & robot_name,
-    const std::string & dock_name);
+    const std::string & receiver_link_name,
+    const std::string & dock_name, const std::string & emitter_link_name);
 
   /// Use this method to check that the models are ready in gazebo before dereferencing their
   /// pointers

--- a/irobot_create_gazebo_plugins/include/irobot_create_gazebo_plugins/gazebo_ros_docking_status.hpp
+++ b/irobot_create_gazebo_plugins/include/irobot_create_gazebo_plugins/gazebo_ros_docking_status.hpp
@@ -1,0 +1,105 @@
+// Copyright 2021 iRobot, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// @author Rodrigo Jose Causarano Nunez (rcausaran@irobot.com)
+
+#ifndef IROBOT_CREATE_GAZEBO_PLUGINS__GAZEBO_ROS_DOCKING_STATUS_HPP_
+#define IROBOT_CREATE_GAZEBO_PLUGINS__GAZEBO_ROS_DOCKING_STATUS_HPP_
+
+#include <gazebo/common/Plugin.hh>
+#include <gazebo/physics/Link.hh>
+#include <gazebo/physics/Model.hh>
+#include <gazebo/physics/World.hh>
+#include <gazebo_ros/conversions/builtin_interfaces.hpp>
+#include <gazebo_ros/node.hpp>
+#include <irobot_create_gazebo_plugins/docking_manager.hpp>
+#include <irobot_create_gazebo_plugins/gazebo_ros_helpers.hpp>
+#include <irobot_create_msgs/msg/dock.hpp>
+#include <irobot_create_msgs/msg/ir_opcode.hpp>
+
+#include <cmath>
+#include <memory>
+
+namespace irobot_create_gazebo_plugins
+{
+class GazeboRosDockingStatus : public gazebo::ModelPlugin
+{
+public:
+  /// Constructor
+  GazeboRosDockingStatus();
+
+  /// Destructor
+  virtual ~GazeboRosDockingStatus() = default;
+
+  /// Gazebo calls this when the plugin is loaded.
+  /// @param model Pointer to parent model. Other plugin types will expose different entities,
+  /// such as `gazebo::sensors::SensorPtr`, `gazebo::physics::WorldPtr`,
+  /// `gazebo::rendering::VisualPtr`, etc.
+  /// @param sdf SDF element containing user-defined parameters.
+  void Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf) override;
+
+  /// Callback to be called at every simulation iteration.
+  void OnUpdate(const gazebo::common::UpdateInfo & info);
+
+  /// Callback to be called every time a new IROpcode message is received
+  void IrOpcodeCb(const irobot_create_msgs::msg::IrOpcode::SharedPtr msg);
+
+private:
+  // Docked thresholds
+  const double DOCKED_DISTANCE{0.065};  // Max distance in meters.
+  const double DOCKED_YAW{0.017};       // Max Yaw between dock and robot in radians.
+
+  // Current dock status
+  bool is_dock_visible_{false};
+  bool is_docked_{false};
+
+  // IROpcode check rate
+  double opcode_check_rate_{20};  // In Hertz, this is lower than IROpcode publish rate.
+
+  // Mutex to protect variables written from different threads
+  std::mutex mutex_;
+
+  /// Connection to world update event. Callback is called while this is alive.
+  gazebo::event::ConnectionPtr update_connection_{nullptr};
+
+  /// Node for ROS communication.
+  gazebo_ros::Node::SharedPtr ros_node_{nullptr};
+
+  /// ROS Dock message
+  irobot_create_msgs::msg::Dock msg_;
+
+  /// ROS publisher
+  rclcpp::Publisher<irobot_create_msgs::msg::Dock>::SharedPtr pub_{nullptr};
+
+  /// ROS Subscription
+  rclcpp::Subscription<irobot_create_msgs::msg::IrOpcode>::SharedPtr sub_{nullptr};
+
+  /// World pointer
+  gazebo::physics::WorldPtr world_{nullptr};
+
+  // DockingManager used to determine if robot is docked
+  std::shared_ptr<DockingManager> dock_manager_;
+
+  /// Last time the status was published
+  gazebo::common::Time last_pub_time_;
+
+  /// Last time the visible status was updated
+  gazebo::common::Time last_visible_update_time_;
+
+  /// Helper class to enforce a specific update rate
+  utils::UpdateRateEnforcer update_rate_enforcer_;
+};
+}  // namespace irobot_create_gazebo_plugins
+
+#endif  // IROBOT_CREATE_GAZEBO_PLUGINS__GAZEBO_ROS_DOCKING_STATUS_HPP_

--- a/irobot_create_gazebo_plugins/src/docking_manager.cpp
+++ b/irobot_create_gazebo_plugins/src/docking_manager.cpp
@@ -21,8 +21,10 @@ namespace irobot_create_gazebo_plugins
 {
 DockingManager::DockingManager(
   const gazebo::physics::WorldPtr & world, const std::string & robot_name,
-  const std::string & dock_name)
-: world_{world}, robot_model_name_{robot_name}, dock_model_name_{dock_name}
+  const std::string & receiver_link_name,
+  const std::string & dock_name, const std::string & emitter_link_name)
+: world_{world}, robot_model_name_{robot_name}, robot_receiver_link_name_{receiver_link_name},
+  dock_model_name_{dock_name}, dock_emitter_link_name_{emitter_link_name}
 {
 }
 
@@ -30,11 +32,11 @@ void DockingManager::initLinks(
   const gazebo::physics::ModelPtr & dock_model, const gazebo::physics::ModelPtr & robot_model)
 {
   // Retrieve receiver link and assert it.
-  receiver_link_ = robot_model->GetLink("ir_omni");
+  receiver_link_ = robot_model->GetLink(robot_receiver_link_name_);
   GZ_ASSERT(receiver_link_, "Receiver link pointer is invalid!");
 
   // Retrieve emitter link and assert it.
-  emitter_link_ = dock_model->GetLink("halo_link");
+  emitter_link_ = dock_model->GetLink(dock_emitter_link_name_);
   GZ_ASSERT(emitter_link_, "Emitter link pointer is invalid!");
 }
 

--- a/irobot_create_gazebo_plugins/src/gazebo_ros_docking_status.cpp
+++ b/irobot_create_gazebo_plugins/src/gazebo_ros_docking_status.cpp
@@ -1,0 +1,154 @@
+// Copyright 2021 iRobot, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// @author Rodrigo Jose Causarano Nunez (rcausaran@irobot.com)
+
+#include <irobot_create_gazebo_plugins/gazebo_ros_docking_status.hpp>
+
+#include <memory>
+#include <string>
+
+namespace irobot_create_gazebo_plugins
+{
+GazeboRosDockingStatus::GazeboRosDockingStatus()
+: ModelPlugin() {}
+
+void GazeboRosDockingStatus::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sdf)
+{
+  // Create a GazeboRos node instead of a common ROS node.
+  // Pass it SDF parameters so common options like namespace and remapping
+  // can be handled.
+  ros_node_ = gazebo_ros::Node::Get(sdf);
+
+  world_ = model->GetWorld();
+  GZ_ASSERT(world_, "World pointer is invalid!");
+
+  double update_rate{1.0};
+  std::string robot_model_name{""};
+  std::string receiver_link_name{""};
+  std::string dock_model_name{""};
+  std::string emitter_link_name{""};
+
+  // Get plugin parameters
+  utils::initialize(update_rate, sdf, "update_rate", 1.0);
+  utils::initialize(robot_model_name, sdf, "robot_model_name", "");
+  utils::initialize(receiver_link_name, sdf, "receiver_link_name", "");
+  utils::initialize(dock_model_name, sdf, "dock_model_name", "");
+  utils::initialize(emitter_link_name, sdf, "emitter_link_name", "");
+
+  // Used to determine if robot is docked or not
+  dock_manager_ = std::make_shared<DockingManager>(
+    world_, robot_model_name, receiver_link_name,
+    dock_model_name, emitter_link_name);
+
+  // Initialize ROS publisher
+  pub_ =
+    ros_node_->create_publisher<irobot_create_msgs::msg::Dock>("~/out", rclcpp::SensorDataQoS());
+
+  sub_ = ros_node_->create_subscription<irobot_create_msgs::msg::IrOpcode>(
+    "/ir_opcode", rclcpp::SensorDataQoS(),
+    std::bind(&GazeboRosDockingStatus::IrOpcodeCb, this, std::placeholders::_1));
+
+  // Set message frame_id
+  msg_.header.frame_id = "base_link";
+
+  // Rate enforcer
+  update_rate_enforcer_.load(update_rate);
+
+  // Create a connection so the OnUpdate function is called at every simulation
+  // iteration.
+  update_connection_ = gazebo::event::Events::ConnectWorldUpdateBegin(
+    std::bind(&GazeboRosDockingStatus::OnUpdate, this, std::placeholders::_1));
+
+  last_pub_time_ = world_->SimTime();
+  last_visible_update_time_ = world_->SimTime();
+
+  RCLCPP_INFO(ros_node_->get_logger(), "Starting ir opcode plugin");
+}
+
+void GazeboRosDockingStatus::OnUpdate(const gazebo::common::UpdateInfo & info)
+{
+  // Check that robot and dock models are spawned
+  if (!dock_manager_->AreModelsReady()) {
+    RCLCPP_WARN_ONCE(ros_node_->get_logger(), "standard_dock model is not ready yet");
+    return;
+  }
+
+  const gazebo::common::Time current_time = info.simTime;
+
+  // Check elapsed time since last publish
+  const double pub_time_elapsed = (current_time - last_pub_time_).Double();
+
+  // Check elapsed time since last dock visible status update
+  const double visible_update_time_elapsed = (current_time - last_visible_update_time_).Double();
+
+
+  {  // This is the lock guard scope to protect is_dock_visible_ and last_visible_update_time_
+    std::lock_guard<std::mutex> lock{mutex_};
+
+    // If opcode not received after the publish period, dock isn't visible
+    const double opcode_check_period = 1 / opcode_check_rate_;
+    if (visible_update_time_elapsed > opcode_check_period) {
+      is_dock_visible_ = false;
+      last_visible_update_time_ = current_time;
+    }
+
+    // Check if docked now
+    utils::PolarCoordinate receiver_wrt_emitter_polar =
+      dock_manager_->ReceiverCartesianPointToEmitterPolarPoint({0.0, 0.0});
+    utils::PolarCoordinate emitter_wrt_receiver_polar =
+      dock_manager_->EmitterCartesianPointToReceiverPolarPoint({0.0, 0.0});
+
+    is_docked_ = receiver_wrt_emitter_polar.radius < DOCKED_DISTANCE &&
+      abs(receiver_wrt_emitter_polar.azimuth) < DOCKED_YAW &&
+      abs(emitter_wrt_receiver_polar.azimuth) < DOCKED_YAW;
+
+    // Check for docking status changes since last publish
+    if (is_docked_ != msg_.is_docked) {
+      RCLCPP_DEBUG_EXPRESSION(
+        ros_node_->get_logger(), is_docked_ != msg_.is_docked,
+        "is_docked_ status change occurred...");
+    }
+    if (is_dock_visible_ != msg_.dock_visible) {
+      RCLCPP_DEBUG_EXPRESSION(
+        ros_node_->get_logger(), is_dock_visible_ != msg_.dock_visible,
+        "is_dock_visible_ status change occurred...");
+    }
+
+    // Publish if docking status changed or if it is time to do so according to publish rate
+    const bool is_changed = is_docked_ != msg_.is_docked || is_dock_visible_ != msg_.dock_visible;
+    if (is_changed || update_rate_enforcer_.shouldUpdate(pub_time_elapsed)) {
+      // Reset time
+      last_pub_time_ = current_time;
+
+      msg_.dock_visible = is_dock_visible_;
+      msg_.is_docked = is_docked_;
+      pub_->publish(msg_);
+      return;
+    }
+  }
+}
+
+void GazeboRosDockingStatus::IrOpcodeCb(const irobot_create_msgs::msg::IrOpcode::SharedPtr msg)
+{
+  std::lock_guard<std::mutex> lock{mutex_};
+
+  // If IROpcode received isn't Virtual Wall, it means the dock is visible
+  is_dock_visible_ = msg->opcode != irobot_create_msgs::msg::IrOpcode::CODE_IR_VIRTUAL_WALL;
+  last_visible_update_time_ = world_->SimTime();
+}
+
+// Register this plugin with the simulator
+GZ_REGISTER_MODEL_PLUGIN(GazeboRosDockingStatus)
+}  // namespace irobot_create_gazebo_plugins

--- a/irobot_create_gazebo_plugins/src/gazebo_ros_ir_opcode.cpp
+++ b/irobot_create_gazebo_plugins/src/gazebo_ros_ir_opcode.cpp
@@ -15,6 +15,7 @@
 // @author Rodrigo Jose Causarano Nunez (rcausaran@irobot.com)
 
 #include <irobot_create_gazebo_plugins/gazebo_ros_ir_opcode.hpp>
+
 #include <memory>
 #include <string>
 
@@ -35,7 +36,10 @@ void GazeboRosIrOpcode::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sd
   GZ_ASSERT(world_, "World pointer is invalid!");
 
   double update_rate{31.0};
-  std::string link_name{""};
+  std::string robot_model_name{""};
+  std::string receiver_link_name{""};
+  std::string dock_model_name{""};
+  std::string emitter_link_name{""};
   double sensor_0_fov{1.0};
   double sensor_0_range{1.0};
   double sensor_1_fov{1.0};
@@ -43,7 +47,10 @@ void GazeboRosIrOpcode::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sd
 
   // Get plugin parameters
   utils::initialize(update_rate, sdf, "update_rate", 31.0);
-  utils::initialize(link_name, sdf, "link_name", "");
+  utils::initialize(robot_model_name, sdf, "robot_model_name", "");
+  utils::initialize(receiver_link_name, sdf, "receiver_link_name", "");
+  utils::initialize(dock_model_name, sdf, "dock_model_name", "");
+  utils::initialize(emitter_link_name, sdf, "emitter_link_name", "");
   utils::initialize(sensor_0_fov, sdf, "sensor_0_fov", 1.0);
   utils::initialize(sensor_0_range, sdf, "sensor_0_range", 1.0);
   utils::initialize(sensor_1_fov, sdf, "sensor_1_fov", 1.0);
@@ -54,14 +61,16 @@ void GazeboRosIrOpcode::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sd
   sensors_[irobot_create_msgs::msg::IrOpcode::SENSOR_DIRECTIONAL_FRONT] = {
     sensor_1_fov, sensor_1_range};
 
-  dock_manager_ = std::make_shared<DockingManager>(world_, "create3", "standard_dock");
+  dock_manager_ = std::make_shared<DockingManager>(
+    world_, robot_model_name, receiver_link_name,
+    dock_model_name, emitter_link_name);
 
   // Initialize ROS publisher
   pub_ = ros_node_->create_publisher<irobot_create_msgs::msg::IrOpcode>(
     "~/out", rclcpp::SensorDataQoS());
 
   // Set message frame_id
-  msg_.header.frame_id = link_name;
+  msg_.header.frame_id = receiver_link_name;
 
   // Rate enforcer
   update_rate_enforcer_.load(update_rate);


### PR DESCRIPTION
## Description

This PR publishes docking status based on the received IR Opcode. 

- If any opcode is received it means that the dock is visible by the robot.
- If Op codes are no longer being received it means the dock is not visible.

Fixes #36 .

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

The robot is teleoperated around the dock. 

- The docking status should be published at 1 Hz while status remains unchanged.
- If dock visibility status or docking status changes, the new status should be immediately published and then go back to publish at 1 Hz until a change occurs

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
