### PR TITLE
Fix wheeldrop event publish

### DIFF
--- a/irobot_create_description/urdf/wheel_drop.urdf.xacro
+++ b/irobot_create_description/urdf/wheel_drop.urdf.xacro
@@ -40,8 +40,8 @@
   <gazebo>
     <plugin name="${wd_link_name}_plugin" filename="libgazebo_ros_create_wheel_drop.so">
       <ros>
-        <namespace>wheel_drop</namespace>
-        <remapping>~/out:=_internal/${name}_wheel/event</remapping>
+        <namespace>/</namespace>
+        <remapping>~/out:=_internal/wheel_drop/${name}_wheel/event</remapping>
       </ros>
       <update_rate>${update_rate}</update_rate>
       <detection_threshold>${detection_threshold}</detection_threshold>


### PR DESCRIPTION
## Description

Wheeldrops was reported to have stopped working. This PR solves the issue by fixing the topic that the events were being published to.
Fixes #82 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

On the master branch you will see nothing published to the wheeldrop topics when dropping the robot from a small height:

- /_internal/wheel_drop/right_wheel/event

- /_internal/wheel_drop/left_wheel/event

After checking out to this commit the same test will throw the desired results

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
