### PR TITLE
Use acceleration limits that better match the robot

### DIFF
--- a/irobot_create_control/config/control.yaml
+++ b/irobot_create_control/config/control.yaml
@@ -53,19 +53,20 @@ diffdrive_controller:
     linear.x.has_jerk_limits: false
     linear.x.max_velocity: 0.306
     linear.x.min_velocity: -0.306
-    linear.x.max_acceleration: 0.9
+    linear.x.max_acceleration: 0.6
     # Not using jerk limits yet
     # linear.x.max_jerk: 0.0
     # linear.x.min_jerk: 0.0
 
     angular.z.has_velocity_limits: true
-    angular.z.has_acceleration_limits: false
+    angular.z.has_acceleration_limits: true
     angular.z.has_jerk_limits: false
     angular.z.max_velocity: 1.9
     angular.z.min_velocity: -1.9
-    # Not using angular acceleration limits yet
-    # angular.z.max_acceleration: 1.0
-    # angular.z.min_acceleration: -1.0
+    # Using 0.6 linear for each wheel, assuming one wheel accel to 600 
+    # and other to -600 with wheelbase leads to 5.15 rad/s^2
+    angular.z.max_acceleration: 5.15
+    angular.z.min_acceleration: -5.15
     # Not using jerk limits yet
     # angular.z.max_jerk: 0.0
     # angular.z.min_jerk: 0.0


### PR DESCRIPTION
Set linear accel limits to what we are commanding on robot along with Twist command.  Get the effective rotational accel limits based on per wheel linear limits and wheel base.  Note, these limits won't take effect until ros2_controllers/diff_drive_controller fixes accel limits.

## Description

Change config file to match robot used limits

Fixes # (issue).

This partially addressed this issue:
https://github.com/iRobotEducation/create3_sim/issues/59
We need to wait for ros2_controllers PR #252 before this issue will take effect.

## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Made same changes in ros2_controller PR #252 by hand to ros2_controller repo referenced by galactic branch.  First set accel limits to 0.01 to confirm they were obeyed.  Then changed limits to config file in PR and confirmed velocity transitions were fast, but not instantaneous as before.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
