### PR TITLE
add timestamp to dock publication

### DIFF
--- a/irobot_create_gazebo_plugins/src/gazebo_ros_docking_status.cpp
+++ b/irobot_create_gazebo_plugins/src/gazebo_ros_docking_status.cpp
@@ -131,7 +131,7 @@ void GazeboRosDockingStatus::OnUpdate(const gazebo::common::UpdateInfo & info)
     if (is_changed || update_rate_enforcer_.shouldUpdate(pub_time_elapsed)) {
       // Reset time
       last_pub_time_ = current_time;
-
+      msg_.header.stamp = gazebo_ros::Convert<builtin_interfaces::msg::Time>(current_time);
       msg_.dock_visible = is_dock_visible_;
       msg_.is_docked = is_docked_;
       pub_->publish(msg_);


### PR DESCRIPTION
Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>

## Description

Set timestamp in the `dock` publication because it was not being populated.

Fixes # (issue).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Start a simulation and check the topic with `ros2 topic echo dock`

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
