### PR TITLE
Fix wheeldrop publishing

### DIFF
--- a/irobot_create_gazebo_plugins/include/irobot_create_gazebo_plugins/gazebo_ros_wheel_drop.hpp
+++ b/irobot_create_gazebo_plugins/include/irobot_create_gazebo_plugins/gazebo_ros_wheel_drop.hpp
@@ -60,8 +60,7 @@ protected:
 
 private:
   /// Publish state
-  void PublishState(
-    const bool & state, const double & range, const gazebo::common::Time & common_time);
+  void PublishWheeldrop(const double & range, const gazebo::common::Time & common_time);
 
   /// Connection to world update event. Callback is called while this is alive.
   gazebo::event::ConnectionPtr update_connection_{nullptr};

--- a/irobot_create_gazebo_plugins/src/gazebo_ros_wheel_drop.cpp
+++ b/irobot_create_gazebo_plugins/src/gazebo_ros_wheel_drop.cpp
@@ -79,31 +79,36 @@ void GazeboRosWheelDrop::OnUpdate()
     return;
   }
 
+  // Check and update wheeldrop status
   const double displacement{joint_->Position()};
   if ((wheel_drop_detected_ == false) && (displacement >= upper_limit_)) {
     wheel_drop_detected_ = true;
   } else if ((wheel_drop_detected_ == true) && (displacement < lower_limit_)) {
     wheel_drop_detected_ = false;
   }
-  if(wheel_drop_detected_) {
-    PublishState(true, displacement, current_time);
+
+  // Publish wheeldrop only if it's in the detected state
+  if (wheel_drop_detected_) {
+    PublishWheeldrop(displacement, current_time);
   }
+
   last_time_ = current_time;
 }
 
-void GazeboRosWheelDrop::PublishState(
-  const bool & state, const double & displacement, const gazebo::common::Time & current_time)
+void GazeboRosWheelDrop::PublishWheeldrop(
+  const double & displacement, const gazebo::common::Time & current_time)
 {
-  wheel_drop_detected_ = state;
   irobot_create_msgs::msg::HazardDetection msg;
   msg.header.stamp = gazebo_ros::Convert<builtin_interfaces::msg::Time>(current_time);
   msg.header.frame_id = frame_id_;
   msg.type = msg.WHEEL_DROP;
   pub_->publish(msg);
   RCLCPP_DEBUG_EXPRESSION(
-    ros_node_->get_logger(), !state, "Wheel drop %s OFF: %.3f", name_.c_str(), displacement);
+    ros_node_->get_logger(), !wheel_drop_detected_, "Wheel drop %s OFF: %.3f",
+    name_.c_str(), displacement);
   RCLCPP_DEBUG_EXPRESSION(
-    ros_node_->get_logger(), state, "Wheel drop %s ON: %.3f", name_.c_str(), displacement);
+    ros_node_->get_logger(), wheel_drop_detected_, "Wheel drop %s ON: %.3f",
+    name_.c_str(), displacement);
 }
 
 // Register this plugin with the simulator


### PR DESCRIPTION
## Description

Fixes wheeldrop plugin. It was only publishing a single event on wheeldrop events. The desired output is a 62Hz publication rate of the status

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

If you balance the robot on top of a vertical cylinder in Gazebo, you should see the wheeldrop status being published at 62Hz

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
