### PR TITLE
use qos matching diff drive controller

### DIFF
--- a/irobot_create_toolbox/src/motion_control_node.cpp
+++ b/irobot_create_toolbox/src/motion_control_node.cpp
@@ -51,7 +51,7 @@ MotionControlNode::MotionControlNode()
     std::bind(&MotionControlNode::commanded_velocity_callback, this, _1));
 
   cmd_vel_out_pub_ = this->create_publisher<geometry_msgs::msg::Twist>(
-    "diffdrive_controller/cmd_vel_unstamped", rclcpp::SensorDataQoS());
+    "diffdrive_controller/cmd_vel_unstamped", rclcpp::SystemDefaultsQoS());
 
   // Register a callback to handle parameter changes
   params_callback_handle_ = this->add_on_set_parameters_callback(


### PR DESCRIPTION
Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>

## Description

This PR fixes a problem that was preventing to use the simulator with cyclonedds.
it matches the qos used in the differential drive controller see https://github.com/ros-controls/ros2_controllers/blob/master/diff_drive_controller/src/diff_drive_controller.cpp#L404

the `rclcpp::SystemDefaultsQoS()` is a very bad qos that should be avoided in general because its dds implementation dependent.


Fixes # (issue).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

this was preventing from running actions or sending velocity commands with 
```
export RMW_IMPLEMENTATION=rmw_cyclonedds_cpp
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
