### PR TITLE
remove unneded dependencies step from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,16 +28,3 @@ jobs:
             irobot_create_gazebo_plugins
             irobot_create_sim
             irobot_create_toolbox
-
-      # ============
-      # DEPENDENCIES
-      # ============
-
-      - name: Dependencies [Ubuntu]
-        shell: bash
-        run: |
-          sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-latest.list'
-          wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
-          sudo apt-get update
-          sudo apt-get install git build-essential cmake libace-dev libeigen3-dev libopencv-dev
-          sudo apt-get install libgazebo11-dev


### PR DESCRIPTION
Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>

## Description

The CI includes a step that installs dependencies.
However I don't think that they are needed and it also happens AFTER the code has been built and unit-tests have been run.

Fixes # (issue).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
Testing with this PR...

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
