### PR TITLE
Add support for reflexes and safety settings

### DIFF
--- a/irobot_create_control/config/control.yaml
+++ b/irobot_create_control/config/control.yaml
@@ -10,6 +10,7 @@ controller_manager:
 
 diffdrive_controller:
   ros__parameters:
+    use_sim_time: True
     left_wheel_names: ["left_wheel_joint"]
     right_wheel_names: ["right_wheel_joint"]
 
@@ -46,14 +47,18 @@ diffdrive_controller:
     # Publish wheel data
     publish_wheel_data: true
 
-    # Velocity and acceleration limits
+    # Velocity and acceleration limits in cartesian
+    # These limits do not factor in per wheel limits
+    # that might be exceeded when linear and angular are combined
     # Whenever a min_* is unspecified, default to -max_*
     linear.x.has_velocity_limits: true
     linear.x.has_acceleration_limits: true
     linear.x.has_jerk_limits: false
-    linear.x.max_velocity: 0.306
-    linear.x.min_velocity: -0.306
-    linear.x.max_acceleration: 0.6
+    # This is max if system is safety_override "full"
+    # motion_control_node will bound this to 0.306 if safety enabled (as is by default)
+    linear.x.max_velocity: 0.46
+    linear.x.min_velocity: -0.46
+    linear.x.max_acceleration: 0.9
     # Not using jerk limits yet
     # linear.x.max_jerk: 0.0
     # linear.x.min_jerk: 0.0
@@ -63,10 +68,10 @@ diffdrive_controller:
     angular.z.has_jerk_limits: false
     angular.z.max_velocity: 1.9
     angular.z.min_velocity: -1.9
-    # Using 0.6 linear for each wheel, assuming one wheel accel to 600 
-    # and other to -600 with wheelbase leads to 5.15 rad/s^2
-    angular.z.max_acceleration: 5.15
-    angular.z.min_acceleration: -5.15
+    # Using 0.9 linear for each wheel, assuming one wheel accel to .9 
+    # and other to -.9 with wheelbase leads to 7.725 rad/s^2
+    angular.z.max_acceleration: 7.725
+    angular.z.min_acceleration: -7.725
     # Not using jerk limits yet
     # angular.z.max_jerk: 0.0
     # angular.z.min_jerk: 0.0

--- a/irobot_create_toolbox/CMakeLists.txt
+++ b/irobot_create_toolbox/CMakeLists.txt
@@ -22,8 +22,10 @@ find_package(nav_msgs REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(rclpy REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
+find_package(tf2_ros REQUIRED)
 
 #### Libraries
 
@@ -37,8 +39,10 @@ set(dependencies
   nav_msgs
   rclcpp
   rclcpp_action
+  std_msgs
   tf2
   tf2_geometry_msgs
+  tf2_ros
 )
 
 add_library(hazard_publisher_lib SHARED)
@@ -69,6 +73,7 @@ target_sources(
   PRIVATE
     src/motion_control_node.cpp
     src/motion_control/docking_behavior.cpp
+    src/motion_control/reflex_behavior.cpp
 )
 target_include_directories(motion_control_lib PUBLIC include)
 ament_target_dependencies(motion_control_lib

--- a/irobot_create_toolbox/include/irobot_create_toolbox/hazards_vector_publisher.hpp
+++ b/irobot_create_toolbox/include/irobot_create_toolbox/hazards_vector_publisher.hpp
@@ -8,6 +8,7 @@
 #include <irobot_create_msgs/msg/hazard_detection_vector.hpp>
 #include <irobot_create_toolbox/parameter_helper.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/bool.hpp>
 #include <string>
 #include <vector>
 
@@ -26,6 +27,8 @@ private:
   // Detection vector publisher
   rclcpp::Publisher<irobot_create_msgs::msg::HazardDetectionVector>::SharedPtr publisher_;
 
+  // Subscription to indicate BACKUP_LIMIT should be published
+  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr backup_limit_subscription_;
   // Vector of subscriptions
   using HazardVectorSubscriptionPtr =
     std::vector<rclcpp::Subscription<irobot_create_msgs::msg::HazardDetection>::SharedPtr>;
@@ -42,6 +45,8 @@ private:
 
   // Message containing a vector to store detected hazards
   irobot_create_msgs::msg::HazardDetectionVector msg_;
+
+  std::atomic<bool> backup_limit_ {false};
 };
 
 }  // namespace irobot_create_toolbox

--- a/irobot_create_toolbox/include/irobot_create_toolbox/motion_control/reflex_behavior.hpp
+++ b/irobot_create_toolbox/include/irobot_create_toolbox/motion_control/reflex_behavior.hpp
@@ -1,0 +1,113 @@
+// Copyright 2021 iRobot Corporation. All Rights Reserved.
+// @author Justin Kearns (jkearns@irobot.com)
+
+#ifndef IROBOT_CREATE_TOOLBOX__MOTION_CONTROL__REFLEX_BEHAVIOR_HPP_
+#define IROBOT_CREATE_TOOLBOX__MOTION_CONTROL__REFLEX_BEHAVIOR_HPP_
+
+#include <irobot_create_msgs/msg/hazard_detection.hpp>
+#include <irobot_create_msgs/msg/hazard_detection_vector.hpp>
+#include <irobot_create_toolbox/motion_control/behaviors_scheduler.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_ros/buffer.h>
+
+#include <atomic>
+#include <memory>
+
+namespace irobot_create_toolbox
+{
+
+/**
+ * @brief This class allows to create and manage Docking and Undocking action
+ * servers.
+ */
+class ReflexBehavior
+{
+public:
+  ReflexBehavior(
+    rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_interface,
+    rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface,
+    rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface,
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_interface,
+    std::shared_ptr<tf2_ros::Buffer> tf_buffer,
+    std::shared_ptr<BehaviorsScheduler> behavior_scheduler);
+  ~ReflexBehavior() = default;
+
+  /// \brief Update reflex manager information
+  //  Reflexes only trigger if robot is moving
+  void update_state(const tf2::Transform& last_robot_pose, bool moving);
+
+private:
+  /// \brief Name of parameter for enabling/disabling all reflexes
+  const std::string reflex_enabled_param_name_{"reflexes_enabled"};
+  /// \brief Map of reflex names to hazard type (max for no support right now)
+  const std::map<std::string, uint8_t> reflex_names_to_hazard_ {
+    {"REFLEX_BUMP", irobot_create_msgs::msg::HazardDetection::BUMP},
+    {"REFLEX_CLIFF", irobot_create_msgs::msg::HazardDetection::CLIFF},
+    {"REFLEX_DOCK_AVOID", std::numeric_limits<uint8_t>::max()},
+    {"REFLEX_GYRO_CAL", std::numeric_limits<uint8_t>::max()},
+    {"REFLEX_PANIC", std::numeric_limits<uint8_t>::max()},
+    {"REFLEX_PROXIMITY_SLOWDOWN", std::numeric_limits<uint8_t>::max()},
+    {"REFLEX_STUCK", irobot_create_msgs::msg::HazardDetection::STALL},
+    {"REFLEX_VIRTUAL_WALL", std::numeric_limits<uint8_t>::max()},
+    {"REFLEX_WHEEL_DROP", irobot_create_msgs::msg::HazardDetection::WHEEL_DROP} };
+  std::mutex hazard_reflex_mutex_;
+  /// \brief Map of hazard driven reflexes with whether they are enabled
+  std::map<uint8_t, bool> hazard_reflex_enabled_ {
+    {irobot_create_msgs::msg::HazardDetection::BUMP, true},
+    {irobot_create_msgs::msg::HazardDetection::CLIFF, true},
+    {irobot_create_msgs::msg::HazardDetection::STALL, true},
+    {irobot_create_msgs::msg::HazardDetection::WHEEL_DROP, true} };
+  /// \brief Whether to use reflexes
+  std::atomic<bool> reflexes_enabled_{true};
+  /// \brief Helper function to declare ROS 2 reflex parameters
+  void declare_parameters(
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_interface);
+
+  /// \brief Helper function to validate changes to parameters
+  rcl_interfaces::msg::SetParametersResult set_parameters_callback(
+          std::vector<rclcpp::Parameter> parameters);
+
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr params_callback_handle_;
+
+  /// \brief Specify whether reflex is enabled or not
+  void enable_reflex(uint8_t reflex, bool enable);
+
+  bool reflex_behavior_is_done();
+
+  void hazard_vector_callback(irobot_create_msgs::msg::HazardDetectionVector::ConstSharedPtr msg);
+
+  boost::optional<tf2::Vector3> get_pose_relative_to_odom(
+    const irobot_create_msgs::msg::HazardDetection & hazard);
+
+  BehaviorsScheduler::optional_output_t execute_reflex();
+
+  rclcpp::Subscription<irobot_create_msgs::msg::HazardDetectionVector>::SharedPtr hazard_detection_sub_;
+
+  rclcpp::Clock::SharedPtr clock_;
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  rclcpp::Logger logger_;
+  std::shared_ptr<BehaviorsScheduler> behavior_scheduler_;
+  std::atomic<bool> running_reflex_ {false};
+  std::mutex robot_pose_mutex_;
+  tf2::Transform last_robot_pose_;
+  tf2::Transform reflex_start_pose_;
+  std::mutex hazard_mutex_;
+  std::vector<irobot_create_msgs::msg::HazardDetection> last_hazards_;
+  rclcpp::Time reflex_start_time_;
+  const rclcpp::Duration max_reflex_runtime_;
+  const double MAX_REFLEX_DISTANCE {0.15};
+  const double MIN_REFLEX_DISTANCE {0.05};
+  const double BACKUP_X_VELOCITY {-0.14};
+  const double ARC_X_VELOCITY {-0.1};
+  const double ARC_ANGULAR_VELOCITY {M_PI/16.0};
+  std::atomic<bool> moving_;
+  std::atomic<bool> driving_backwards_ {false};
+  const std::string odom_frame_ {"odom"};
+  const std::string base_frame_ {"base_link"};
+  BehaviorsScheduler::optional_output_t last_reflex_cmd_;
+};
+
+}  // namespace irobot_create_toolbox
+#endif  // IROBOT_CREATE_TOOLBOX__MOTION_CONTROL__REFLEX_BEHAVIOR_HPP_

--- a/irobot_create_toolbox/include/irobot_create_toolbox/motion_control/reflex_behavior.hpp
+++ b/irobot_create_toolbox/include/irobot_create_toolbox/motion_control/reflex_behavior.hpp
@@ -13,7 +13,11 @@
 #include <tf2_ros/buffer.h>
 
 #include <atomic>
+#include <limits>
+#include <map>
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace irobot_create_toolbox
 {
@@ -36,7 +40,7 @@ public:
 
   /// \brief Update reflex manager information
   //  Reflexes only trigger if robot is moving
-  void update_state(const tf2::Transform& last_robot_pose, bool moving);
+  void update_state(const tf2::Transform & last_robot_pose, bool moving);
 
 private:
   /// \brief Name of parameter for enabling/disabling all reflexes
@@ -51,14 +55,14 @@ private:
     {"REFLEX_PROXIMITY_SLOWDOWN", std::numeric_limits<uint8_t>::max()},
     {"REFLEX_STUCK", irobot_create_msgs::msg::HazardDetection::STALL},
     {"REFLEX_VIRTUAL_WALL", std::numeric_limits<uint8_t>::max()},
-    {"REFLEX_WHEEL_DROP", irobot_create_msgs::msg::HazardDetection::WHEEL_DROP} };
+    {"REFLEX_WHEEL_DROP", irobot_create_msgs::msg::HazardDetection::WHEEL_DROP}};
   std::mutex hazard_reflex_mutex_;
   /// \brief Map of hazard driven reflexes with whether they are enabled
   std::map<uint8_t, bool> hazard_reflex_enabled_ {
     {irobot_create_msgs::msg::HazardDetection::BUMP, true},
     {irobot_create_msgs::msg::HazardDetection::CLIFF, true},
     {irobot_create_msgs::msg::HazardDetection::STALL, true},
-    {irobot_create_msgs::msg::HazardDetection::WHEEL_DROP, true} };
+    {irobot_create_msgs::msg::HazardDetection::WHEEL_DROP, true}};
   /// \brief Whether to use reflexes
   std::atomic<bool> reflexes_enabled_{true};
   /// \brief Helper function to declare ROS 2 reflex parameters
@@ -67,7 +71,7 @@ private:
 
   /// \brief Helper function to validate changes to parameters
   rcl_interfaces::msg::SetParametersResult set_parameters_callback(
-          std::vector<rclcpp::Parameter> parameters);
+    std::vector<rclcpp::Parameter> parameters);
 
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr params_callback_handle_;
 
@@ -83,7 +87,8 @@ private:
 
   BehaviorsScheduler::optional_output_t execute_reflex();
 
-  rclcpp::Subscription<irobot_create_msgs::msg::HazardDetectionVector>::SharedPtr hazard_detection_sub_;
+  rclcpp::Subscription<irobot_create_msgs::msg::HazardDetectionVector>::SharedPtr
+    hazard_detection_sub_;
 
   rclcpp::Clock::SharedPtr clock_;
   std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
@@ -101,7 +106,7 @@ private:
   const double MIN_REFLEX_DISTANCE {0.05};
   const double BACKUP_X_VELOCITY {-0.14};
   const double ARC_X_VELOCITY {-0.1};
-  const double ARC_ANGULAR_VELOCITY {M_PI/16.0};
+  const double ARC_ANGULAR_VELOCITY {M_PI / 16.0};
   std::atomic<bool> moving_;
   std::atomic<bool> driving_backwards_ {false};
   const std::string odom_frame_ {"odom"};

--- a/irobot_create_toolbox/include/irobot_create_toolbox/motion_control_node.hpp
+++ b/irobot_create_toolbox/include/irobot_create_toolbox/motion_control_node.hpp
@@ -5,9 +5,14 @@
 #define IROBOT_CREATE_TOOLBOX__MOTION_CONTROL_NODE_HPP_
 
 #include <geometry_msgs/msg/twist.hpp>
+#include <irobot_create_msgs/msg/kidnap_status.hpp>
 #include <irobot_create_toolbox/parameter_helper.hpp>
 #include <irobot_create_toolbox/motion_control/docking_behavior.hpp>
+#include <irobot_create_toolbox/motion_control/reflex_behavior.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/bool.hpp>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
 #include <memory>
 #include <string>
 #include <vector>
@@ -26,9 +31,6 @@ private:
   /// \brief Clear any cached teleop command
   void reset_last_teleop_cmd();
 
-  /// \brief Helper function to declare ROS 2 reflex parameters
-  void declare_reflex_parameters();
-
   /// \brief Helper function to declare ROS 2 safety parameters
   void declare_safety_parameters();
 
@@ -36,19 +38,24 @@ private:
   rcl_interfaces::msg::SetParametersResult set_parameters_callback(
     const std::vector<rclcpp::Parameter> & parameters);
 
-  /// \brief Name of parameter for enabling/disabling all reflexes
-  const std::string reflex_enabled_param_name_{"reflexes_enabled"};
-  /// \brief Vector of reflex names (these corresponds to exposed parameters)
-  const std::vector<std::string> reflex_names_{
-    "REFLEX_BUMP", "REFLEX_CLIFF", "REFLEX_DOCK_AVOID",
-    "REFLEX_GYRO_CAL", "REFLEX_PANIC", "REFLEX_PROXIMITY_SLOWDOWN",
-    "REFLEX_STUCK", "REFLEX_VIRTUAL_WALL", "REFLEX_WHEEL_DROP"};
+  enum class SafetyOverrideMode {
+      NONE,
+      BACKUP_ONLY,
+      FULL
+  };
+  const std::map<std::string, SafetyOverrideMode> safety_to_str_ {
+      {"none", SafetyOverrideMode::NONE},
+      {"backup_only", SafetyOverrideMode::BACKUP_ONLY},
+      {"full", SafetyOverrideMode::FULL}
+  };
   /// \brief Name of parameter for setting system safety mode,
   //     which dictates cliff safety and max speed
   const std::string safety_override_param_name_{"safety_override"};
   /// \brief Name of parameter for reporting system's max speed,
   //     this will be changed by system based on safety_override setting
   const std::string max_speed_param_name_{"max_speed"};
+
+  bool set_safety_mode(const std::string& safety_mode);
   /// \brief Storage for custom parameter validation callbacks
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr params_callback_handle_{
     nullptr};
@@ -56,17 +63,47 @@ private:
   /// \brief Callback for new velocity commands
   void commanded_velocity_callback(geometry_msgs::msg::Twist::ConstSharedPtr msg);
 
+  /// \brief Callback for robot odometry
+  void robot_pose_callback(nav_msgs::msg::Odometry::ConstSharedPtr msg);
+
+  /// \brief Callback for kidnap status
+  void kidnap_callback(irobot_create_msgs::msg::KidnapStatus::ConstSharedPtr msg);
+
+  /// \brief Given command, bound by max speed, checking each wheel
+  void bound_command_by_limits(geometry_msgs::msg::Twist& cmd);
+
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr teleop_subscription_;
+  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_pose_sub_;
+  rclcpp::Subscription<irobot_create_msgs::msg::KidnapStatus>::SharedPtr kidnap_sub_;
   rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr cmd_vel_out_pub_;
+  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr backup_buffer_low_pub_;
   rclcpp::TimerBase::SharedPtr timer_;
+
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer_;
+  std::shared_ptr<tf2_ros::TransformListener> tf_listener_;
 
   std::shared_ptr<BehaviorsScheduler> scheduler_;
   std::shared_ptr<DockingBehavior> docking_behavior_;
+  std::shared_ptr<ReflexBehavior> reflex_behavior_;
 
   std::mutex mutex_;
   geometry_msgs::msg::Twist last_teleop_cmd_;
   rclcpp::Time last_teleop_ts_;
   rclcpp::Duration wheels_stop_threshold_;
+  std::atomic<bool> allow_speed_param_change_ {false};
+  std::atomic<SafetyOverrideMode> safety_override_mode_ {SafetyOverrideMode::NONE};
+  const double SAFETY_ON_MAX_SPEED {0.306};
+  const double SAFETY_OFF_MAX_SPEED {0.46};
+  double max_speed_ {SAFETY_ON_MAX_SPEED};
+  const double wheel_base_ {0.233};
+  double backup_buffer_ {0.0};
+  std::mutex robot_pose_mutex_;
+  tf2::Transform last_robot_pose_;
+  tf2::Transform last_backup_pose_;
+  std::atomic<bool> last_kidnap_ {false};
+  rclcpp::Time backup_print_ts_;
+  rclcpp::Time auto_override_print_ts_;
+  const rclcpp::Duration repeat_print_;
 };
 
 }  // namespace irobot_create_toolbox

--- a/irobot_create_toolbox/include/irobot_create_toolbox/motion_control_node.hpp
+++ b/irobot_create_toolbox/include/irobot_create_toolbox/motion_control_node.hpp
@@ -13,6 +13,7 @@
 #include <std_msgs/msg/bool.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -38,15 +39,16 @@ private:
   rcl_interfaces::msg::SetParametersResult set_parameters_callback(
     const std::vector<rclcpp::Parameter> & parameters);
 
-  enum class SafetyOverrideMode {
-      NONE,
-      BACKUP_ONLY,
-      FULL
+  enum class SafetyOverrideMode
+  {
+    NONE,
+    BACKUP_ONLY,
+    FULL
   };
   const std::map<std::string, SafetyOverrideMode> safety_to_str_ {
-      {"none", SafetyOverrideMode::NONE},
-      {"backup_only", SafetyOverrideMode::BACKUP_ONLY},
-      {"full", SafetyOverrideMode::FULL}
+    {"none", SafetyOverrideMode::NONE},
+    {"backup_only", SafetyOverrideMode::BACKUP_ONLY},
+    {"full", SafetyOverrideMode::FULL}
   };
   /// \brief Name of parameter for setting system safety mode,
   //     which dictates cliff safety and max speed
@@ -55,7 +57,7 @@ private:
   //     this will be changed by system based on safety_override setting
   const std::string max_speed_param_name_{"max_speed"};
 
-  bool set_safety_mode(const std::string& safety_mode);
+  bool set_safety_mode(const std::string & safety_mode);
   /// \brief Storage for custom parameter validation callbacks
   rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr params_callback_handle_{
     nullptr};
@@ -70,7 +72,7 @@ private:
   void kidnap_callback(irobot_create_msgs::msg::KidnapStatus::ConstSharedPtr msg);
 
   /// \brief Given command, bound by max speed, checking each wheel
-  void bound_command_by_limits(geometry_msgs::msg::Twist& cmd);
+  void bound_command_by_limits(geometry_msgs::msg::Twist & cmd);
 
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr teleop_subscription_;
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr odom_pose_sub_;

--- a/irobot_create_toolbox/src/hazards_vector_publisher.cpp
+++ b/irobot_create_toolbox/src/hazards_vector_publisher.cpp
@@ -59,10 +59,10 @@ HazardsVectorPublisher::HazardsVectorPublisher()
     RCLCPP_INFO_STREAM(get_logger(), "Subscription to topic: " << topic);
   }
   backup_limit_subscription_ = this->create_subscription<std_msgs::msg::Bool>(
-        "_internal/backup_buffer_low", rclcpp::SensorDataQoS(),
-        [this](std_msgs::msg::Bool::ConstSharedPtr msg) {
-            backup_limit_ = msg->data;
-        });
+    "_internal/backup_buffer_low", rclcpp::SensorDataQoS(),
+    [this](std_msgs::msg::Bool::ConstSharedPtr msg) {
+      backup_limit_ = msg->data;
+    });
 }
 
 }  // namespace irobot_create_toolbox

--- a/irobot_create_toolbox/src/hazards_vector_publisher.cpp
+++ b/irobot_create_toolbox/src/hazards_vector_publisher.cpp
@@ -31,6 +31,13 @@ HazardsVectorPublisher::HazardsVectorPublisher()
 
       // Set header timestamp.
       this->msg_.header.stamp = now();
+      if (backup_limit_) {
+        irobot_create_msgs::msg::HazardDetection backup_hazard;
+        backup_hazard.header.frame_id = "base_link";
+        backup_hazard.header.stamp = this->msg_.header.stamp;
+        backup_hazard.type = irobot_create_msgs::msg::HazardDetection::BACKUP_LIMIT;
+        this->msg_.detections.push_back(backup_hazard);
+      }
 
       // Publish detected vector.
       this->publisher_->publish(this->msg_);
@@ -51,6 +58,11 @@ HazardsVectorPublisher::HazardsVectorPublisher()
         })));
     RCLCPP_INFO_STREAM(get_logger(), "Subscription to topic: " << topic);
   }
+  backup_limit_subscription_ = this->create_subscription<std_msgs::msg::Bool>(
+        "_internal/backup_buffer_low", rclcpp::SensorDataQoS(),
+        [this](std_msgs::msg::Bool::ConstSharedPtr msg) {
+            backup_limit_ = msg->data;
+        });
 }
 
 }  // namespace irobot_create_toolbox

--- a/irobot_create_toolbox/src/motion_control/docking_behavior.cpp
+++ b/irobot_create_toolbox/src/motion_control/docking_behavior.cpp
@@ -153,6 +153,7 @@ void DockingBehavior::handle_dock_servo_accepted(
   BehaviorsScheduler::BehaviorsData data;
   data.run_func = std::bind(&DockingBehavior::execute_dock_servo, this, goal_handle);
   data.is_done_func = std::bind(&DockingBehavior::docking_behavior_is_done, this);
+  data.interruptable = true;
 
   const bool ret = behavior_scheduler_->set_behavior(data);
   if (!ret) {
@@ -287,6 +288,7 @@ void DockingBehavior::handle_undock_accepted(
   BehaviorsScheduler::BehaviorsData data;
   data.run_func = std::bind(&DockingBehavior::execute_undock, this, goal_handle);
   data.is_done_func = std::bind(&DockingBehavior::docking_behavior_is_done, this);
+  data.interruptable = true;
 
   const bool ret = behavior_scheduler_->set_behavior(data);
   if (!ret) {

--- a/irobot_create_toolbox/src/motion_control/reflex_behavior.cpp
+++ b/irobot_create_toolbox/src/motion_control/reflex_behavior.cpp
@@ -1,0 +1,383 @@
+// Copyright 2021 iRobot Corporation. All Rights Reserved.
+// @author Justin Kearns (jkearns@irobot.com)
+
+#include <geometry_msgs/msg/twist.hpp>
+#include <irobot_create_toolbox/motion_control/reflex_behavior.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+
+#include <memory>
+
+namespace irobot_create_toolbox
+{
+
+using namespace std::placeholders;
+
+ReflexBehavior::ReflexBehavior(
+  rclcpp::node_interfaces::NodeClockInterface::SharedPtr node_clock_interface,
+  rclcpp::node_interfaces::NodeLoggingInterface::SharedPtr node_logging_interface,
+  rclcpp::node_interfaces::NodeTopicsInterface::SharedPtr node_topics_interface,
+  rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_interface,
+  std::shared_ptr<tf2_ros::Buffer> tf_buffer,
+  std::shared_ptr<BehaviorsScheduler> behavior_scheduler)
+: clock_(node_clock_interface->get_clock()),
+  tf_buffer_(tf_buffer),
+  logger_(node_logging_interface->get_logger()),
+  max_reflex_runtime_(rclcpp::Duration(std::chrono::seconds(10)))
+{
+  behavior_scheduler_ = behavior_scheduler;
+
+  hazard_detection_sub_ = rclcpp::create_subscription<irobot_create_msgs::msg::HazardDetectionVector>(
+    node_topics_interface,
+    "hazard_detection",
+    rclcpp::SensorDataQoS(),
+    std::bind(&ReflexBehavior::hazard_vector_callback, this, _1));
+
+  // Declare ROS 2 parameters and setup the system according to default values
+  this->declare_parameters(node_parameters_interface);
+
+  // Register a callback to handle parameter changes
+  params_callback_handle_ = node_parameters_interface->add_on_set_parameters_callback(
+        std::bind(&ReflexBehavior::set_parameters_callback, this, _1));
+
+  // Give poses default value, will be over-written by subscriptions
+  reflex_start_pose_.setIdentity();
+  reflex_start_time_ = clock_->now();
+}
+
+void ReflexBehavior::update_state(const tf2::Transform& last_robot_pose,
+          bool moving)
+{
+    moving_ = moving;
+    const std::lock_guard<std::mutex> lock(robot_pose_mutex_);
+    last_robot_pose_ = last_robot_pose;
+}
+
+bool ReflexBehavior::reflex_behavior_is_done()
+{
+  return !running_reflex_;
+}
+
+void ReflexBehavior::declare_parameters(
+    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_interface)
+{
+  rcl_interfaces::msg::ParameterDescriptor descriptor;
+  descriptor.read_only = false;
+  rclcpp::ParameterValue ret;
+
+  // Declare parameters to enable or disable each of the supported reflexes
+  for (const auto & reflex_hazard : reflex_names_to_hazard_) {
+    uint8_t hazard_type = reflex_hazard.second;
+    bool default_enabled = hazard_type != std::numeric_limits<uint8_t>::max();
+    const std::string reflex_param_name = std::string("reflexes.") + reflex_hazard.first;
+    ret = node_parameters_interface->declare_parameter(reflex_param_name, rclcpp::ParameterValue(default_enabled), descriptor);
+    if (!default_enabled && ret.get<bool>()) {
+      RCLCPP_ERROR(
+        logger_, "Trying to enable reflex: '%s'. This is not supported yet.",
+        reflex_hazard.first.c_str());
+      throw std::runtime_error("User tried to enable reflexes. This are not supported yet.");
+    }
+    this->enable_reflex(hazard_type, ret.get<bool>());
+  }
+
+  // Declare parameter to enable or disable the reflex arbiter
+  ret = node_parameters_interface->declare_parameter(reflex_enabled_param_name_, rclcpp::ParameterValue(true), descriptor);
+  reflexes_enabled_ = ret.get<bool>();
+}
+
+rcl_interfaces::msg::SetParametersResult ReflexBehavior::set_parameters_callback(std::vector<rclcpp::Parameter> parameters)
+{
+  auto result = rcl_interfaces::msg::SetParametersResult();
+  result.successful = true;
+
+  bool updated_param = false;
+
+  for (const rclcpp::Parameter &parameter : parameters) {
+    bool invalid_delete = false;
+    rclcpp::ParameterType parameter_type = parameter.get_type();
+    if (rclcpp::ParameterType::PARAMETER_NOT_SET == parameter_type) {
+        invalid_delete = true;
+    }
+    // Check if string starts with reflexes.
+    const std::string& param_name = parameter.get_name();
+    if (param_name.rfind("reflexes.", 0) == 0) {
+        // Get string after reflexes.
+        std::size_t dot_pos = param_name.find(".");
+        // Get string starting after .
+        std::string reflex_name = param_name.substr (dot_pos+1);
+        auto it = reflex_names_to_hazard_.find(reflex_name);
+        if (it != reflex_names_to_hazard_.end()) {
+            if (!invalid_delete) {
+                this->enable_reflex(it->second, parameter.get_value<bool>());
+                updated_param = true;
+            }
+        }
+    } else if (parameter.get_name().compare(reflex_enabled_param_name_) == 0) {
+        if (!invalid_delete) {
+            reflexes_enabled_ = parameter.get_value<bool>();
+            updated_param = true;
+        }
+    }
+    if (!updated_param) {
+      // not handled by this component
+      continue;
+    } else if (invalid_delete) {
+        RCLCPP_WARN(logger_, "Can't delete parameter '%s'", parameter.get_name().c_str());
+        result.successful = false;
+        result.reason = "parameter \'"+parameter.get_name()+"\' cannot be deleted";
+    }
+  }
+  return result;   
+}
+
+void ReflexBehavior::enable_reflex(uint8_t reflex, bool enable)
+{
+    const std::lock_guard<std::mutex> lock(hazard_reflex_mutex_);
+    std::map<uint8_t, bool>::iterator hazard_reflex = hazard_reflex_enabled_.find(reflex);
+    if (hazard_reflex != hazard_reflex_enabled_.end()) {
+        hazard_reflex->second = enable;
+        // Print reflex being enabled/disabled
+        for (const auto& name: reflex_names_to_hazard_) {
+            if (name.second == reflex) {
+                if (enable) {
+                    RCLCPP_INFO(logger_, "Enabling %s", name.first.c_str());
+                } else {
+                    RCLCPP_INFO(logger_, "Disabling %s", name.first.c_str());
+                }
+            }
+        }
+    }
+}
+
+BehaviorsScheduler::optional_output_t ReflexBehavior::execute_reflex()
+{
+  BehaviorsScheduler::optional_output_t servo_cmd;
+  enum class DriveAwayDirection {
+      NONE,
+      PURE_BACKUP,
+      ARC_CLOCKWISE,
+      ARC_COUNTER_CLOCKWISE
+  };
+  DriveAwayDirection drive_dir = DriveAwayDirection::NONE;
+  {
+    // Check active reflexes
+    const std::lock_guard<std::mutex> lock(hazard_mutex_);
+    for (const auto& hazard: last_hazards_) {
+        switch (hazard.type) {
+            case irobot_create_msgs::msg::HazardDetection::BUMP:
+            {
+                drive_dir = DriveAwayDirection::PURE_BACKUP;
+                break;
+            }
+            case irobot_create_msgs::msg::HazardDetection::CLIFF:
+            {
+                if (drive_dir != DriveAwayDirection::PURE_BACKUP) {
+                    boost::optional<tf2::Vector3> hazard_offset =
+                        get_pose_relative_to_odom(hazard);
+                    if (hazard_offset) {
+                        if (hazard_offset->getY() > 0) {
+                            if (drive_dir == DriveAwayDirection::ARC_COUNTER_CLOCKWISE) {
+                                drive_dir = DriveAwayDirection::PURE_BACKUP;
+                            } else {
+                                drive_dir = DriveAwayDirection::ARC_CLOCKWISE;
+                            }
+                        } else {
+                            if (drive_dir == DriveAwayDirection::ARC_CLOCKWISE) {
+                                drive_dir = DriveAwayDirection::PURE_BACKUP;
+                            } else {
+                                drive_dir = DriveAwayDirection::ARC_COUNTER_CLOCKWISE;
+                            }
+                        }
+                    }
+                }
+                break;
+            }
+            case irobot_create_msgs::msg::HazardDetection::STALL:
+            {
+                drive_dir = DriveAwayDirection::PURE_BACKUP;
+                break;
+            }
+            case irobot_create_msgs::msg::HazardDetection::WHEEL_DROP:
+            {
+                drive_dir = DriveAwayDirection::PURE_BACKUP;
+                break;
+            }
+            case irobot_create_msgs::msg::HazardDetection::BACKUP_LIMIT:
+            case irobot_create_msgs::msg::HazardDetection::OBJECT_PROXIMITY:
+                // We do not trigger a reflex on these types of hazards
+                break;
+        }
+    }
+  }
+  bool finish_reflex = false;
+  // Get next command
+  tf2::Transform robot_pose(tf2::Transform::getIdentity());
+  {
+    const std::lock_guard<std::mutex> lock(robot_pose_mutex_);
+    robot_pose = last_robot_pose_;
+  }
+  // See if robot has done too much without clearing hazard
+  tf2::Vector3 delta_pose = robot_pose.getOrigin() - reflex_start_pose_.getOrigin();
+  double distance_since_hazard = 0.0;
+  if (driving_backwards_) {
+      distance_since_hazard = std::hypot(delta_pose.getX(), delta_pose.getY());
+  } else {
+      tf2::Transform relative_motion = reflex_start_pose_.inverseTimes(robot_pose);
+      if (relative_motion.getOrigin().getX() < 0.0) {
+          driving_backwards_ = true;
+      }
+  }
+  if (drive_dir == DriveAwayDirection::NONE && distance_since_hazard > MIN_REFLEX_DISTANCE) {
+    finish_reflex = true;
+  } else if (distance_since_hazard > MAX_REFLEX_DISTANCE) {
+    RCLCPP_WARN(logger_, "Reflex Exceeded Max Travel Distance without clearing hazard");
+    finish_reflex = true;
+  } else if (clock_->now() - reflex_start_time_ > max_reflex_runtime_) {
+    RCLCPP_WARN(logger_, "Reflex Exceeded Runtime without clearing hazard");
+    finish_reflex = true;
+  }
+
+
+  if (finish_reflex) {
+    running_reflex_ = false;
+  } else if (drive_dir != DriveAwayDirection::NONE) {
+    // Pick velocity to escape hazards based on hazard types and locations
+    servo_cmd = geometry_msgs::msg::Twist();
+    switch(drive_dir) {
+      case DriveAwayDirection::PURE_BACKUP:
+      {
+        servo_cmd->linear.x = BACKUP_X_VELOCITY;
+        break;
+      }
+      case DriveAwayDirection::ARC_CLOCKWISE:
+      {
+        servo_cmd->linear.x = ARC_X_VELOCITY;
+        servo_cmd->angular.z = -ARC_ANGULAR_VELOCITY;
+        break;
+      }
+      case DriveAwayDirection::ARC_COUNTER_CLOCKWISE:
+      {
+        servo_cmd->linear.x = ARC_X_VELOCITY;
+        servo_cmd->angular.z = ARC_ANGULAR_VELOCITY;
+        break;
+      }
+      case DriveAwayDirection::NONE: // this code path is covered above
+          break;
+    }
+  } else {
+      // If here, we don't have a hazard, but haven't traveled the min distance
+      // keep last command
+      servo_cmd = last_reflex_cmd_;
+  }
+  last_reflex_cmd_ = servo_cmd;
+
+  return servo_cmd;
+}
+
+void ReflexBehavior::hazard_vector_callback(irobot_create_msgs::msg::HazardDetectionVector::ConstSharedPtr msg)
+{
+  if (running_reflex_) {
+    // Just cache the data for processing by execute_reflex
+    const std::lock_guard<std::mutex> lock(hazard_mutex_);
+    last_hazards_ = msg->detections;
+  } else {
+    // Don't trigger reflex is robot isn't driving
+    if (!moving_ || !reflexes_enabled_) return;
+    // If hazard is triggered, start reflex
+    bool hazard_detected = false;
+    for (const auto& hazard: msg->detections) {
+        bool reflex_enabled_for_hazard = false;
+        {
+            const std::lock_guard<std::mutex> lock(hazard_reflex_mutex_);
+            // See if reflex for this hazard is enabled
+            std::map<uint8_t, bool>::const_iterator hazard_reflex =
+                hazard_reflex_enabled_.find(hazard.type);
+            if (hazard_reflex == hazard_reflex_enabled_.end()) {
+                // hazard doesn't have corresponding reflex
+                continue;
+            }
+            reflex_enabled_for_hazard = hazard_reflex->second;
+        }
+        if (reflex_enabled_for_hazard) {
+            switch (hazard.type) {
+                case irobot_create_msgs::msg::HazardDetection::BUMP:
+                case irobot_create_msgs::msg::HazardDetection::CLIFF:
+                case irobot_create_msgs::msg::HazardDetection::STALL:
+                case irobot_create_msgs::msg::HazardDetection::WHEEL_DROP:
+                    hazard_detected = true;
+                    break;
+
+                case irobot_create_msgs::msg::HazardDetection::BACKUP_LIMIT:
+                case irobot_create_msgs::msg::HazardDetection::OBJECT_PROXIMITY:
+                    // We do not trigger a reflex on these types of hazards
+                    break;
+            }
+            if (hazard_detected) {
+                // Only need one hazard to trigger a reflex
+                break;
+            }
+        }
+    }
+    // If reflex enabled for hazard, run reflex
+    if (hazard_detected) {
+      last_hazards_ = msg->detections;
+      BehaviorsScheduler::BehaviorsData data;
+      data.run_func = std::bind(&ReflexBehavior::execute_reflex, this);
+      data.is_done_func = std::bind(&ReflexBehavior::reflex_behavior_is_done, this);
+      data.interruptable = false;
+
+      running_reflex_ = behavior_scheduler_->set_behavior(data);
+      if (running_reflex_) {
+        reflex_start_time_ = clock_->now();
+        {
+          const std::lock_guard<std::mutex> lock(robot_pose_mutex_);
+          reflex_start_pose_ = last_robot_pose_;
+        }
+        driving_backwards_ = false;
+      }
+    }
+  }
+}
+
+boost::optional<tf2::Vector3> ReflexBehavior::get_pose_relative_to_odom(
+        const irobot_create_msgs::msg::HazardDetection & hazard)
+{
+  try {
+    geometry_msgs::msg::TransformStamped odom_hazard =
+        tf_buffer_->lookupTransform(hazard.header.frame_id, odom_frame_,
+                hazard.header.stamp);
+    geometry_msgs::msg::TransformStamped odom_now =
+        tf_buffer_->lookupTransform(base_frame_, odom_frame_,
+                rclcpp::Time(0));
+    // Get difference between when hazard was observed and current odometry
+    tf2::Stamped<tf2::Transform> odom_hazard_tf;
+    tf2::fromMsg(odom_hazard, odom_hazard_tf);
+    tf2::Stamped<tf2::Transform> odom_now_tf;
+    tf2::fromMsg(odom_now, odom_now_tf);
+    tf2::Transform diff_tf = odom_now_tf.inverseTimes(odom_hazard_tf);
+    return diff_tf.getOrigin();
+  } catch (tf2::LookupException & ex) {
+    RCLCPP_ERROR(
+      logger_,
+      "No Transform available Error looking up target frame: %s\n", ex.what());
+  } catch (tf2::ConnectivityException & ex) {
+    RCLCPP_ERROR(
+      logger_,
+      "Connectivity Error looking up target frame: %s\n", ex.what());
+  } catch (tf2::ExtrapolationException & ex) {
+    RCLCPP_ERROR(
+      logger_,
+      "Extrapolation Error looking up target frame: %s\n", ex.what());
+  } catch (tf2::TimeoutException & ex) {
+    RCLCPP_ERROR(
+      logger_,
+      "Transform timeout");
+  } catch (tf2::TransformException & ex) {
+    RCLCPP_ERROR(
+      logger_, "Failed to transform from %s to %s",
+      odom_frame_.c_str(), hazard.header.frame_id.c_str());
+  }
+
+  return boost::optional<tf2::Vector3>();
+}
+
+}  // namespace irobot_create_toolbox

--- a/irobot_create_toolbox/src/motion_control/reflex_behavior.cpp
+++ b/irobot_create_toolbox/src/motion_control/reflex_behavior.cpp
@@ -5,7 +5,11 @@
 #include <irobot_create_toolbox/motion_control/reflex_behavior.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
+#include <limits>
+#include <map>
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace irobot_create_toolbox
 {
@@ -26,7 +30,8 @@ ReflexBehavior::ReflexBehavior(
 {
   behavior_scheduler_ = behavior_scheduler;
 
-  hazard_detection_sub_ = rclcpp::create_subscription<irobot_create_msgs::msg::HazardDetectionVector>(
+  hazard_detection_sub_ =
+    rclcpp::create_subscription<irobot_create_msgs::msg::HazardDetectionVector>(
     node_topics_interface,
     "hazard_detection",
     rclcpp::SensorDataQoS(),
@@ -37,19 +42,20 @@ ReflexBehavior::ReflexBehavior(
 
   // Register a callback to handle parameter changes
   params_callback_handle_ = node_parameters_interface->add_on_set_parameters_callback(
-        std::bind(&ReflexBehavior::set_parameters_callback, this, _1));
+    std::bind(&ReflexBehavior::set_parameters_callback, this, _1));
 
   // Give poses default value, will be over-written by subscriptions
   reflex_start_pose_.setIdentity();
   reflex_start_time_ = clock_->now();
 }
 
-void ReflexBehavior::update_state(const tf2::Transform& last_robot_pose,
-          bool moving)
+void ReflexBehavior::update_state(
+  const tf2::Transform & last_robot_pose,
+  bool moving)
 {
-    moving_ = moving;
-    const std::lock_guard<std::mutex> lock(robot_pose_mutex_);
-    last_robot_pose_ = last_robot_pose;
+  moving_ = moving;
+  const std::lock_guard<std::mutex> lock(robot_pose_mutex_);
+  last_robot_pose_ = last_robot_pose;
 }
 
 bool ReflexBehavior::reflex_behavior_is_done()
@@ -58,7 +64,7 @@ bool ReflexBehavior::reflex_behavior_is_done()
 }
 
 void ReflexBehavior::declare_parameters(
-    rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_interface)
+  rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_interface)
 {
   rcl_interfaces::msg::ParameterDescriptor descriptor;
   descriptor.read_only = false;
@@ -69,7 +75,10 @@ void ReflexBehavior::declare_parameters(
     uint8_t hazard_type = reflex_hazard.second;
     bool default_enabled = hazard_type != std::numeric_limits<uint8_t>::max();
     const std::string reflex_param_name = std::string("reflexes.") + reflex_hazard.first;
-    ret = node_parameters_interface->declare_parameter(reflex_param_name, rclcpp::ParameterValue(default_enabled), descriptor);
+    ret =
+      node_parameters_interface->declare_parameter(
+      reflex_param_name, rclcpp::ParameterValue(
+        default_enabled), descriptor);
     if (!default_enabled && ret.get<bool>()) {
       RCLCPP_ERROR(
         logger_, "Trying to enable reflex: '%s'. This is not supported yet.",
@@ -80,132 +89,136 @@ void ReflexBehavior::declare_parameters(
   }
 
   // Declare parameter to enable or disable the reflex arbiter
-  ret = node_parameters_interface->declare_parameter(reflex_enabled_param_name_, rclcpp::ParameterValue(true), descriptor);
+  ret = node_parameters_interface->declare_parameter(
+    reflex_enabled_param_name_, rclcpp::ParameterValue(
+      true), descriptor);
   reflexes_enabled_ = ret.get<bool>();
 }
 
-rcl_interfaces::msg::SetParametersResult ReflexBehavior::set_parameters_callback(std::vector<rclcpp::Parameter> parameters)
+rcl_interfaces::msg::SetParametersResult ReflexBehavior::set_parameters_callback(
+  std::vector<rclcpp::Parameter> parameters)
 {
   auto result = rcl_interfaces::msg::SetParametersResult();
   result.successful = true;
 
   bool updated_param = false;
 
-  for (const rclcpp::Parameter &parameter : parameters) {
+  for (const rclcpp::Parameter & parameter : parameters) {
     bool invalid_delete = false;
     rclcpp::ParameterType parameter_type = parameter.get_type();
     if (rclcpp::ParameterType::PARAMETER_NOT_SET == parameter_type) {
-        invalid_delete = true;
+      invalid_delete = true;
     }
     // Check if string starts with reflexes.
-    const std::string& param_name = parameter.get_name();
+    const std::string & param_name = parameter.get_name();
     if (param_name.rfind("reflexes.", 0) == 0) {
-        // Get string after reflexes.
-        std::size_t dot_pos = param_name.find(".");
-        // Get string starting after .
-        std::string reflex_name = param_name.substr (dot_pos+1);
-        auto it = reflex_names_to_hazard_.find(reflex_name);
-        if (it != reflex_names_to_hazard_.end()) {
-            if (!invalid_delete) {
-                this->enable_reflex(it->second, parameter.get_value<bool>());
-                updated_param = true;
-            }
-        }
-    } else if (parameter.get_name().compare(reflex_enabled_param_name_) == 0) {
+      // Get string after reflexes.
+      std::size_t dot_pos = param_name.find(".");
+      // Get string starting after .
+      std::string reflex_name = param_name.substr(dot_pos + 1);
+      auto it = reflex_names_to_hazard_.find(reflex_name);
+      if (it != reflex_names_to_hazard_.end()) {
         if (!invalid_delete) {
-            reflexes_enabled_ = parameter.get_value<bool>();
-            updated_param = true;
+          this->enable_reflex(it->second, parameter.get_value<bool>());
+          updated_param = true;
         }
+      }
+    } else if (parameter.get_name().compare(reflex_enabled_param_name_) == 0) {
+      if (!invalid_delete) {
+        reflexes_enabled_ = parameter.get_value<bool>();
+        updated_param = true;
+      }
     }
     if (!updated_param) {
       // not handled by this component
       continue;
     } else if (invalid_delete) {
-        RCLCPP_WARN(logger_, "Can't delete parameter '%s'", parameter.get_name().c_str());
-        result.successful = false;
-        result.reason = "parameter \'"+parameter.get_name()+"\' cannot be deleted";
+      RCLCPP_WARN(logger_, "Can't delete parameter '%s'", parameter.get_name().c_str());
+      result.successful = false;
+      result.reason = "parameter \'" + parameter.get_name() + "\' cannot be deleted";
     }
   }
-  return result;   
+  return result;
 }
 
 void ReflexBehavior::enable_reflex(uint8_t reflex, bool enable)
 {
-    const std::lock_guard<std::mutex> lock(hazard_reflex_mutex_);
-    std::map<uint8_t, bool>::iterator hazard_reflex = hazard_reflex_enabled_.find(reflex);
-    if (hazard_reflex != hazard_reflex_enabled_.end()) {
-        hazard_reflex->second = enable;
-        // Print reflex being enabled/disabled
-        for (const auto& name: reflex_names_to_hazard_) {
-            if (name.second == reflex) {
-                if (enable) {
-                    RCLCPP_INFO(logger_, "Enabling %s", name.first.c_str());
-                } else {
-                    RCLCPP_INFO(logger_, "Disabling %s", name.first.c_str());
-                }
-            }
+  const std::lock_guard<std::mutex> lock(hazard_reflex_mutex_);
+  std::map<uint8_t, bool>::iterator hazard_reflex = hazard_reflex_enabled_.find(reflex);
+  if (hazard_reflex != hazard_reflex_enabled_.end()) {
+    hazard_reflex->second = enable;
+    // Print reflex being enabled/disabled
+    for (const auto & name : reflex_names_to_hazard_) {
+      if (name.second == reflex) {
+        if (enable) {
+          RCLCPP_INFO(logger_, "Enabling %s", name.first.c_str());
+        } else {
+          RCLCPP_INFO(logger_, "Disabling %s", name.first.c_str());
         }
+      }
     }
+  }
 }
 
 BehaviorsScheduler::optional_output_t ReflexBehavior::execute_reflex()
 {
   BehaviorsScheduler::optional_output_t servo_cmd;
-  enum class DriveAwayDirection {
-      NONE,
-      PURE_BACKUP,
-      ARC_CLOCKWISE,
-      ARC_COUNTER_CLOCKWISE
+  enum class DriveAwayDirection
+  {
+    NONE,
+    PURE_BACKUP,
+    ARC_CLOCKWISE,
+    ARC_COUNTER_CLOCKWISE
   };
   DriveAwayDirection drive_dir = DriveAwayDirection::NONE;
   {
     // Check active reflexes
     const std::lock_guard<std::mutex> lock(hazard_mutex_);
-    for (const auto& hazard: last_hazards_) {
-        switch (hazard.type) {
-            case irobot_create_msgs::msg::HazardDetection::BUMP:
-            {
-                drive_dir = DriveAwayDirection::PURE_BACKUP;
-                break;
-            }
-            case irobot_create_msgs::msg::HazardDetection::CLIFF:
-            {
-                if (drive_dir != DriveAwayDirection::PURE_BACKUP) {
-                    boost::optional<tf2::Vector3> hazard_offset =
-                        get_pose_relative_to_odom(hazard);
-                    if (hazard_offset) {
-                        if (hazard_offset->getY() > 0) {
-                            if (drive_dir == DriveAwayDirection::ARC_COUNTER_CLOCKWISE) {
-                                drive_dir = DriveAwayDirection::PURE_BACKUP;
-                            } else {
-                                drive_dir = DriveAwayDirection::ARC_CLOCKWISE;
-                            }
-                        } else {
-                            if (drive_dir == DriveAwayDirection::ARC_CLOCKWISE) {
-                                drive_dir = DriveAwayDirection::PURE_BACKUP;
-                            } else {
-                                drive_dir = DriveAwayDirection::ARC_COUNTER_CLOCKWISE;
-                            }
-                        }
-                    }
+    for (const auto & hazard : last_hazards_) {
+      switch (hazard.type) {
+        case irobot_create_msgs::msg::HazardDetection::BUMP:
+          {
+            drive_dir = DriveAwayDirection::PURE_BACKUP;
+            break;
+          }
+        case irobot_create_msgs::msg::HazardDetection::CLIFF:
+          {
+            if (drive_dir != DriveAwayDirection::PURE_BACKUP) {
+              boost::optional<tf2::Vector3> hazard_offset =
+                get_pose_relative_to_odom(hazard);
+              if (hazard_offset) {
+                if (hazard_offset->getY() > 0) {
+                  if (drive_dir == DriveAwayDirection::ARC_COUNTER_CLOCKWISE) {
+                    drive_dir = DriveAwayDirection::PURE_BACKUP;
+                  } else {
+                    drive_dir = DriveAwayDirection::ARC_CLOCKWISE;
+                  }
+                } else {
+                  if (drive_dir == DriveAwayDirection::ARC_CLOCKWISE) {
+                    drive_dir = DriveAwayDirection::PURE_BACKUP;
+                  } else {
+                    drive_dir = DriveAwayDirection::ARC_COUNTER_CLOCKWISE;
+                  }
                 }
-                break;
+              }
             }
-            case irobot_create_msgs::msg::HazardDetection::STALL:
-            {
-                drive_dir = DriveAwayDirection::PURE_BACKUP;
-                break;
-            }
-            case irobot_create_msgs::msg::HazardDetection::WHEEL_DROP:
-            {
-                drive_dir = DriveAwayDirection::PURE_BACKUP;
-                break;
-            }
-            case irobot_create_msgs::msg::HazardDetection::BACKUP_LIMIT:
-            case irobot_create_msgs::msg::HazardDetection::OBJECT_PROXIMITY:
-                // We do not trigger a reflex on these types of hazards
-                break;
-        }
+            break;
+          }
+        case irobot_create_msgs::msg::HazardDetection::STALL:
+          {
+            drive_dir = DriveAwayDirection::PURE_BACKUP;
+            break;
+          }
+        case irobot_create_msgs::msg::HazardDetection::WHEEL_DROP:
+          {
+            drive_dir = DriveAwayDirection::PURE_BACKUP;
+            break;
+          }
+        case irobot_create_msgs::msg::HazardDetection::BACKUP_LIMIT:
+        case irobot_create_msgs::msg::HazardDetection::OBJECT_PROXIMITY:
+          // We do not trigger a reflex on these types of hazards
+          break;
+      }
     }
   }
   bool finish_reflex = false;
@@ -219,12 +232,12 @@ BehaviorsScheduler::optional_output_t ReflexBehavior::execute_reflex()
   tf2::Vector3 delta_pose = robot_pose.getOrigin() - reflex_start_pose_.getOrigin();
   double distance_since_hazard = 0.0;
   if (driving_backwards_) {
-      distance_since_hazard = std::hypot(delta_pose.getX(), delta_pose.getY());
+    distance_since_hazard = std::hypot(delta_pose.getX(), delta_pose.getY());
   } else {
-      tf2::Transform relative_motion = reflex_start_pose_.inverseTimes(robot_pose);
-      if (relative_motion.getOrigin().getX() < 0.0) {
-          driving_backwards_ = true;
-      }
+    tf2::Transform relative_motion = reflex_start_pose_.inverseTimes(robot_pose);
+    if (relative_motion.getOrigin().getX() < 0.0) {
+      driving_backwards_ = true;
+    }
   }
   if (drive_dir == DriveAwayDirection::NONE && distance_since_hazard > MIN_REFLEX_DISTANCE) {
     finish_reflex = true;
@@ -242,38 +255,39 @@ BehaviorsScheduler::optional_output_t ReflexBehavior::execute_reflex()
   } else if (drive_dir != DriveAwayDirection::NONE) {
     // Pick velocity to escape hazards based on hazard types and locations
     servo_cmd = geometry_msgs::msg::Twist();
-    switch(drive_dir) {
+    switch (drive_dir) {
       case DriveAwayDirection::PURE_BACKUP:
-      {
-        servo_cmd->linear.x = BACKUP_X_VELOCITY;
-        break;
-      }
-      case DriveAwayDirection::ARC_CLOCKWISE:
-      {
-        servo_cmd->linear.x = ARC_X_VELOCITY;
-        servo_cmd->angular.z = -ARC_ANGULAR_VELOCITY;
-        break;
-      }
-      case DriveAwayDirection::ARC_COUNTER_CLOCKWISE:
-      {
-        servo_cmd->linear.x = ARC_X_VELOCITY;
-        servo_cmd->angular.z = ARC_ANGULAR_VELOCITY;
-        break;
-      }
-      case DriveAwayDirection::NONE: // this code path is covered above
+        {
+          servo_cmd->linear.x = BACKUP_X_VELOCITY;
           break;
+        }
+      case DriveAwayDirection::ARC_CLOCKWISE:
+        {
+          servo_cmd->linear.x = ARC_X_VELOCITY;
+          servo_cmd->angular.z = -ARC_ANGULAR_VELOCITY;
+          break;
+        }
+      case DriveAwayDirection::ARC_COUNTER_CLOCKWISE:
+        {
+          servo_cmd->linear.x = ARC_X_VELOCITY;
+          servo_cmd->angular.z = ARC_ANGULAR_VELOCITY;
+          break;
+        }
+      case DriveAwayDirection::NONE:  // this code path is covered above
+        break;
     }
   } else {
-      // If here, we don't have a hazard, but haven't traveled the min distance
-      // keep last command
-      servo_cmd = last_reflex_cmd_;
+    // If here, we don't have a hazard, but haven't traveled the min distance
+    // keep last command
+    servo_cmd = last_reflex_cmd_;
   }
   last_reflex_cmd_ = servo_cmd;
 
   return servo_cmd;
 }
 
-void ReflexBehavior::hazard_vector_callback(irobot_create_msgs::msg::HazardDetectionVector::ConstSharedPtr msg)
+void ReflexBehavior::hazard_vector_callback(
+  irobot_create_msgs::msg::HazardDetectionVector::ConstSharedPtr msg)
 {
   if (running_reflex_) {
     // Just cache the data for processing by execute_reflex
@@ -281,41 +295,41 @@ void ReflexBehavior::hazard_vector_callback(irobot_create_msgs::msg::HazardDetec
     last_hazards_ = msg->detections;
   } else {
     // Don't trigger reflex is robot isn't driving
-    if (!moving_ || !reflexes_enabled_) return;
+    if (!moving_ || !reflexes_enabled_) {return;}
     // If hazard is triggered, start reflex
     bool hazard_detected = false;
-    for (const auto& hazard: msg->detections) {
-        bool reflex_enabled_for_hazard = false;
-        {
-            const std::lock_guard<std::mutex> lock(hazard_reflex_mutex_);
-            // See if reflex for this hazard is enabled
-            std::map<uint8_t, bool>::const_iterator hazard_reflex =
-                hazard_reflex_enabled_.find(hazard.type);
-            if (hazard_reflex == hazard_reflex_enabled_.end()) {
-                // hazard doesn't have corresponding reflex
-                continue;
-            }
-            reflex_enabled_for_hazard = hazard_reflex->second;
+    for (const auto & hazard : msg->detections) {
+      bool reflex_enabled_for_hazard = false;
+      {
+        const std::lock_guard<std::mutex> lock(hazard_reflex_mutex_);
+        // See if reflex for this hazard is enabled
+        std::map<uint8_t, bool>::const_iterator hazard_reflex =
+          hazard_reflex_enabled_.find(hazard.type);
+        if (hazard_reflex == hazard_reflex_enabled_.end()) {
+          // hazard doesn't have corresponding reflex
+          continue;
         }
-        if (reflex_enabled_for_hazard) {
-            switch (hazard.type) {
-                case irobot_create_msgs::msg::HazardDetection::BUMP:
-                case irobot_create_msgs::msg::HazardDetection::CLIFF:
-                case irobot_create_msgs::msg::HazardDetection::STALL:
-                case irobot_create_msgs::msg::HazardDetection::WHEEL_DROP:
-                    hazard_detected = true;
-                    break;
+        reflex_enabled_for_hazard = hazard_reflex->second;
+      }
+      if (reflex_enabled_for_hazard) {
+        switch (hazard.type) {
+          case irobot_create_msgs::msg::HazardDetection::BUMP:
+          case irobot_create_msgs::msg::HazardDetection::CLIFF:
+          case irobot_create_msgs::msg::HazardDetection::STALL:
+          case irobot_create_msgs::msg::HazardDetection::WHEEL_DROP:
+            hazard_detected = true;
+            break;
 
-                case irobot_create_msgs::msg::HazardDetection::BACKUP_LIMIT:
-                case irobot_create_msgs::msg::HazardDetection::OBJECT_PROXIMITY:
-                    // We do not trigger a reflex on these types of hazards
-                    break;
-            }
-            if (hazard_detected) {
-                // Only need one hazard to trigger a reflex
-                break;
-            }
+          case irobot_create_msgs::msg::HazardDetection::BACKUP_LIMIT:
+          case irobot_create_msgs::msg::HazardDetection::OBJECT_PROXIMITY:
+            // We do not trigger a reflex on these types of hazards
+            break;
         }
+        if (hazard_detected) {
+          // Only need one hazard to trigger a reflex
+          break;
+        }
+      }
     }
     // If reflex enabled for hazard, run reflex
     if (hazard_detected) {
@@ -339,15 +353,17 @@ void ReflexBehavior::hazard_vector_callback(irobot_create_msgs::msg::HazardDetec
 }
 
 boost::optional<tf2::Vector3> ReflexBehavior::get_pose_relative_to_odom(
-        const irobot_create_msgs::msg::HazardDetection & hazard)
+  const irobot_create_msgs::msg::HazardDetection & hazard)
 {
   try {
     geometry_msgs::msg::TransformStamped odom_hazard =
-        tf_buffer_->lookupTransform(hazard.header.frame_id, odom_frame_,
-                hazard.header.stamp);
+      tf_buffer_->lookupTransform(
+      hazard.header.frame_id, odom_frame_,
+      hazard.header.stamp);
     geometry_msgs::msg::TransformStamped odom_now =
-        tf_buffer_->lookupTransform(base_frame_, odom_frame_,
-                rclcpp::Time(0));
+      tf_buffer_->lookupTransform(
+      base_frame_, odom_frame_,
+      rclcpp::Time(0));
     // Get difference between when hazard was observed and current odometry
     tf2::Stamped<tf2::Transform> odom_hazard_tf;
     tf2::fromMsg(odom_hazard, odom_hazard_tf);


### PR DESCRIPTION
## Description

* Add reflexes that override cmd_vel and actions to drive robot away from its detected hazards
* Implement safety_override param exposing difference backup and speed modes for the robot
* Implement BACKUP_LIMIT hazard and backup stop policy when safety_override is "none"
* Set max system speed to 0.46 for use when safety_override is "full", motion_control_node limits to 0.306 when not
* Fix time for odom publication
* Increase acceleration limits to 0.9 (also increasing on robot)

Fixes # (issue).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested driving around with different safety modes, ensuring different speeds and backup policies.  Verified backup_limits reporting and stopping when safety_override "none".  Verified bump triggers when driving against things in AWS house.  Verified robot swerves when hard coded cliff triggering in hazard publication.  Verified /odom publication now correctly publishes with sim_time


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
