### PR TITLE
Fixes two warnings

### DIFF
--- a/irobot_create_control/config/control.yaml
+++ b/irobot_create_control/config/control.yaml
@@ -1,6 +1,6 @@
 controller_manager:
   ros__parameters:
-    update_rate: 100  # Hz
+    update_rate: 1000  # Hz
 
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
@@ -68,7 +68,7 @@ diffdrive_controller:
     angular.z.has_jerk_limits: false
     angular.z.max_velocity: 1.9
     angular.z.min_velocity: -1.9
-    # Using 0.9 linear for each wheel, assuming one wheel accel to .9 
+    # Using 0.9 linear for each wheel, assuming one wheel accel to .9
     # and other to -.9 with wheelbase leads to 7.725 rad/s^2
     angular.z.max_acceleration: 7.725
     angular.z.min_acceleration: -7.725

--- a/irobot_create_control/launch/include/control.py
+++ b/irobot_create_control/launch/include/control.py
@@ -19,7 +19,7 @@ def generate_launch_description():
 
     diffdrive_controller_node = Node(
         package='controller_manager',
-        executable='spawner.py',
+        executable='spawner',
         parameters=[control_params_file],
         arguments=['diffdrive_controller', '-c', '/controller_manager'],
         output='screen',
@@ -27,7 +27,7 @@ def generate_launch_description():
 
     joint_state_broadcaster_spawner = Node(
         package='controller_manager',
-        executable='spawner.py',
+        executable='spawner',
         arguments=['joint_state_broadcaster', '-c', '/controller_manager'],
         output='screen',
     )


### PR DESCRIPTION
This PR prevents a couple of warnings from appearing when launching the simulation:

- Fixes ".py" deprecated warning
- Fixes diffdrive slower than gazebo update rate warning