### PR TITLE
Updated URDF to work with both gazebo classic and ignition

### DIFF
--- a/irobot_create_common_bringup/launch/dock_description.launch.py
+++ b/irobot_create_common_bringup/launch/dock_description.launch.py
@@ -10,7 +10,11 @@ from launch.substitutions import Command, LaunchConfiguration, PathJoinSubstitut
 from launch_ros.actions import Node
 
 
-ARGUMENTS = []
+ARGUMENTS = [
+    DeclareLaunchArgument('gazebo', default_value='classic',
+                          choices=['classic', 'ignition'],
+                          description='Which gazebo simulation to use')
+]
 for pose_element in ['x', 'y', 'z', 'yaw']:
     ARGUMENTS.append(DeclareLaunchArgument(f'{pose_element}', default_value='0.0',
                      description=f'{pose_element} component of the dock pose.'))
@@ -34,7 +38,7 @@ def generate_launch_description():
         output='screen',
         parameters=[
             {'use_sim_time': True},
-            {'robot_description': Command(['xacro', ' ', dock_xacro_file])},
+            {'robot_description': Command(['xacro', ' ', dock_xacro_file, ' ', 'gazebo:=', LaunchConfiguration('gazebo')])},
         ],
         remappings=[
             ('robot_description', 'standard_dock_description'),

--- a/irobot_create_common_bringup/launch/robot_description.launch.py
+++ b/irobot_create_common_bringup/launch/robot_description.launch.py
@@ -6,7 +6,9 @@
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.substitutions import Command, PathJoinSubstitution
+from launch.substitutions.launch_configuration import LaunchConfiguration
 from launch_ros.actions import Node
+from launch.actions import DeclareLaunchArgument
 
 
 def generate_launch_description():
@@ -20,7 +22,7 @@ def generate_launch_description():
         output='screen',
         parameters=[
             {'use_sim_time': True},
-            {'robot_description': Command(['xacro', ' ', xacro_file])},
+            {'robot_description': Command(['xacro', ' ', xacro_file, ' ', 'gazebo:=', LaunchConfiguration('gazebo')])},
         ],
     )
 
@@ -32,7 +34,11 @@ def generate_launch_description():
     )
 
     # Define LaunchDescription variable
-    ld = LaunchDescription()
+    ld = LaunchDescription([
+        DeclareLaunchArgument('gazebo', default_value='classic',
+                          choices=['classic', 'ignition'],
+                          description='Which gazebo simulation to use')]
+    )
     # Add nodes to LaunchDescription
     ld.add_action(joint_state_publisher)
     ld.add_action(robot_state_publisher)

--- a/irobot_create_description/urdf/bumper.urdf.xacro
+++ b/irobot_create_description/urdf/bumper.urdf.xacro
@@ -15,7 +15,7 @@ functional, while the 4 remaining ones are created as dummy links. -->
   <link name="${link_name}"/>
 </xacro:macro>
 
-<xacro:macro name="bumper" params="name:=bump_front_center parent_link:=base_link update_rate:=62.0 visual_mesh collision_mesh
+<xacro:macro name="bumper" params="name:=bump_front_center parent_link:=base_link update_rate:=62.0 gazebo visual_mesh collision_mesh
   *origin *inertial">
   <xacro:property name="link_name" value="${name}"/>
   <xacro:property name="joint_name" value="${name}_joint"/>
@@ -52,13 +52,14 @@ functional, while the 4 remaining ones are created as dummy links. -->
       <contact>
         <collision>${link_name}_collision</collision>
       </contact>
-      <plugin name="${name}_plugin" filename="libgazebo_ros_create_bumper.so">
-        <ros>
-          <namespace>/</namespace>
-          <remapping>~/out:=_internal/bumper/event</remapping>
-        </ros>
-      </plugin>
-
+      <xacro:if value="${gazebo == 'classic'}">
+        <plugin name="${name}_plugin" filename="libgazebo_ros_create_bumper.so">
+          <ros>
+            <namespace>/</namespace>
+            <remapping>~/out:=_internal/bumper/event</remapping>
+          </ros>
+        </plugin>
+      </xacro:if>
     </sensor>
   </gazebo>
 

--- a/irobot_create_description/urdf/common_properties.urdf.xacro
+++ b/irobot_create_description/urdf/common_properties.urdf.xacro
@@ -47,6 +47,79 @@
     <xacro:inertial_cuboid mass="0.01" x="0.01" y="0.01" z="0.01"/>
   </xacro:macro>
 
+  <xacro:macro name="ray_sensor" 
+    params="sensor_name gazebo update_rate visualize 
+            h_samples h_res h_min_angle h_max_angle
+            v_samples:=1 v_res:=1 v_min_angle:=0 v_max_angle:=0
+            r_min r_max r_res *plugin">
+    <!-- Classic -->
+    <xacro:if value="${gazebo == 'classic'}">
+      <sensor type="ray" name="${sensor_name}">
+        <update_rate>${update_rate}</update_rate>
+        <visualize>${visualize}</visualize>
+        <always_on>true</always_on>
+        <ray>
+          <scan>
+            <horizontal>
+              <samples>${h_samples}</samples>
+              <resolution>${h_res}</resolution>
+              <min_angle>${h_min_angle}</min_angle>
+              <max_angle>${h_max_angle}</max_angle>
+            </horizontal>
+            <vertical>
+              <samples>${v_samples}</samples>
+              <resolution>${v_res}</resolution>
+              <min_angle>${v_min_angle}</min_angle>
+              <max_angle>${v_max_angle}</max_angle>
+            </vertical>
+          </scan>
+          <range>
+            <min>${r_min}</min>
+            <max>${r_max}</max>
+            <resolution>${r_res}</resolution>
+          </range>
+        </ray>
+        <!-- Noise is currently disabled -->
+        <noise>
+          <type>gaussian</type>
+          <mean>0.0</mean>
+          <stddev>0.0</stddev>
+        </noise>
+        <xacro:insert_block name="plugin"/>
+      </sensor>
+    </xacro:if>
+
+    <!-- Ignition -->
+    <xacro:if value="${gazebo == 'ignition'}">
+      <sensor name="${sensor_name}" type="gpu_lidar">
+        <update_rate>${update_rate}</update_rate>
+        <visualize>${visualize}</visualize>
+        <always_on>true</always_on>
+        <lidar>
+          <scan>
+            <horizontal>
+              <samples>${h_samples}</samples>
+              <resolution>${h_res}</resolution>
+              <min_angle>${h_min_angle}</min_angle>
+              <max_angle>${h_max_angle}</max_angle>
+            </horizontal>
+            <vertical>
+              <samples>${v_samples}</samples>
+              <resolution>${v_res}</resolution>
+              <min_angle>${v_min_angle}</min_angle>
+              <max_angle>${v_max_angle}</max_angle>
+            </vertical>
+          </scan>
+          <range>
+            <min>${r_min}</min>
+            <max>${r_max}</max>
+            <resolution>${r_res}</resolution>
+          </range>
+        </lidar>
+      </sensor>
+    </xacro:if>
+  </xacro:macro>
+
   <!-- Conversion macros -->
   <xacro:property name="cm2m"    value="${1/100.0}"/>
   <xacro:property name="mm2m"    value="${1/1000.0}"/>
@@ -59,5 +132,26 @@
       <color rgba="0.1 0.1 0.1 1"/>
     </material>
   </xacro:property>
+
+  <!-- Material macros -->
+  <xacro:macro name="material_black">
+    <visual>
+      <material>
+        <diffuse>0 0 0 1</diffuse>
+        <specular>${80/255} ${80/255} ${80/255} 1</specular>
+        <emissive>0 0 0 1</emissive>
+      </material>
+    </visual>
+  </xacro:macro>
+
+  <xacro:macro name="material_darkgray">
+    <visual>
+      <material>
+        <diffuse>${3/255} ${3/255} ${3/255} 1</diffuse>
+        <specular>0 0 0 1</specular>
+        <emissive>0 0 0 1</emissive>
+      </material>
+    </visual>
+  </xacro:macro>
 
 </robot>

--- a/irobot_create_description/urdf/create3.urdf.xacro
+++ b/irobot_create_description/urdf/create3.urdf.xacro
@@ -11,6 +11,9 @@
   <xacro:include filename="$(find irobot_create_description)/urdf/sensors/optical_mouse.urdf.xacro"/>
   <xacro:include filename="$(find irobot_create_description)/urdf/wheel_with_wheeldrop.urdf.xacro" />
 
+  <!-- Gazebo version -->
+  <xacro:arg name="gazebo"                       default="classic" />
+
   <!-- Mechanical properties -->
   <xacro:property name="body_z_offset"           value="${-2.5*cm2m}" />
   <xacro:property name="body_collision_z_offset" value="${1*cm2m}" />
@@ -20,14 +23,14 @@
 
   <xacro:property name="bumper_mass"             value="0.1" />
   <xacro:property name="bumper_offset_z"         value="${-2.5*cm2m}" />
-  <xacro:property name="bumber_inertial_x"       value="${8*cm2m}" />
+  <xacro:property name="bumper_inertial_x"       value="${8*cm2m}" />
   <xacro:property name="bumper_inertial_z"       value="${2*cm2m}"/>
 
   <xacro:property name="wheel_height"            value="${-2.75*cm2m}" />
   <xacro:property name="distance_between_wheels" value="${23.3*cm2m}" />
 
   <xacro:property name="caster_position_x"       value="${12.5*cm2m}" />
-  <xacro:property name="caster_position_z"       value="${-5.55*cm2m}" />
+  <xacro:property name="caster_position_z"       value="${-5.25*cm2m}" />
 
   <xacro:property name="wheel_drop_offset_z"     value="${3.5*mm2m}"/>
   <xacro:property name="wheel_drop_z"            value="${wheel_height + wheel_drop_offset_z}"/>
@@ -59,13 +62,20 @@
     </xacro:inertial_cylinder_with_pose>
   </link>
 
+  <xacro:if value="${'$(arg gazebo)' == 'ignition'}">
+    <gazebo reference="base_link">
+      <xacro:material_darkgray/>
+    </gazebo>
+  </xacro:if>
+
   <!-- Bumper -->
   <xacro:bumper
+      gazebo="$(arg gazebo)"
       visual_mesh="file://$(find irobot_create_description)/meshes/bumper_visual.dae"
       collision_mesh="file://$(find irobot_create_description)/meshes/bumper_collision.dae">
     <origin xyz="0 0 ${bumper_offset_z  + base_link_z_offset}"/>
     <inertial>
-      <origin xyz="${bumber_inertial_x} 0 ${bumper_inertial_z}"/>
+      <origin xyz="${bumper_inertial_x} 0 ${bumper_inertial_z}"/>
       <mass value="${bumper_mass}"/>
       <inertia ixx="0.0013483753405" ixy="0.0000000454352" ixz="0.0000014434849"
                iyy="0.0002521736852" iyz="-0.0000000006721" izz="0.0015442525386"/>
@@ -73,11 +83,11 @@
   </xacro:bumper>
 
   <!-- Wheels with mechanical wheel drop -->
-  <xacro:wheel_with_wheeldrop name="left">
+  <xacro:wheel_with_wheeldrop name="left" gazebo="$(arg gazebo)">
     <origin xyz="0 ${distance_between_wheels/2} ${wheel_drop_z  + base_link_z_offset}" rpy="${-pi/2} 0 0"/>
   </xacro:wheel_with_wheeldrop>
 
-  <xacro:wheel_with_wheeldrop name="right">
+  <xacro:wheel_with_wheeldrop name="right" gazebo="$(arg gazebo)">
     <origin xyz="0 ${-distance_between_wheels/2} ${wheel_drop_z  + base_link_z_offset}" rpy="${-pi/2} 0 0"/>
   </xacro:wheel_with_wheeldrop>
 
@@ -87,18 +97,20 @@
   </xacro:caster>
 
   <!-- IMU -->
-  <xacro:imu_sensor>
+  <xacro:imu_sensor gazebo="$(arg gazebo)">
     <origin xyz="0.050613 0.043673 ${0.0202 + base_link_z_offset}"/>
   </xacro:imu_sensor>
 
-  <gazebo>
-    <plugin name="gazebo_ros2_control" filename="libgazebo_ros2_control.so">
-      <parameters> $(find irobot_create_control)/config/control.yaml </parameters>
-    </plugin>
-  </gazebo>
+  <xacro:if value="${'$(arg gazebo)' == 'classic'}">
+    <gazebo>
+      <plugin name="gazebo_ros2_control" filename="libgazebo_ros2_control.so">
+        <parameters> $(find irobot_create_control)/config/control.yaml </parameters>
+      </plugin>
+    </gazebo>
+  </xacro:if>
 
   <!-- Mouse -->
-  <xacro:optical_mouse>
+  <xacro:optical_mouse gazebo="$(arg gazebo)">
     <origin xyz="0.1015 0.087 ${-0.055 + base_link_z_offset}" rpy="0 0 ${-pi/4}"/>
   </xacro:optical_mouse>
 
@@ -111,26 +123,26 @@
   <xacro:property name="cliff_center_yaw" value="${65.3*deg2rad}"/>
 
   <xacro:property name="cliff_back_x" value="${6*cm2m}"/>
-  <xacro:property name="cliff_back_y" value="${-14.5*cm2m}"/>
+  <xacro:property name="cliff_back_y" value="${14.5*cm2m}"/>
   <xacro:property name="cliff_back_pitch" value="${80*deg2rad}"/>
   <xacro:property name="cliff_back_yaw" value="${167.4*deg2rad}"/>
 
-  <xacro:cliff_sensor name="side_left">
+  <xacro:cliff_sensor name="side_left" gazebo="$(arg gazebo)">
     <origin xyz="${cliff_back_x} ${cliff_back_y} ${cliff_z + base_link_z_offset}"
             rpy="0 ${cliff_back_pitch} ${cliff_back_yaw}"/>
   </xacro:cliff_sensor>
 
-  <xacro:cliff_sensor name="side_right">
+  <xacro:cliff_sensor name="side_right" gazebo="$(arg gazebo)">
     <origin xyz="${cliff_back_x} ${- cliff_back_y} ${cliff_z + base_link_z_offset}"
             rpy="0 ${cliff_back_pitch} ${- cliff_back_yaw}"/>
   </xacro:cliff_sensor>
 
-  <xacro:cliff_sensor name="front_left">
+  <xacro:cliff_sensor name="front_left" gazebo="$(arg gazebo)">
     <origin xyz="${cliff_center_x} ${cliff_center_y} ${cliff_z + base_link_z_offset}"
             rpy="0 ${cliff_center_pitch} ${cliff_center_yaw}"/>
   </xacro:cliff_sensor>
 
-  <xacro:cliff_sensor name="front_right">
+  <xacro:cliff_sensor name="front_right" gazebo="$(arg gazebo)">
     <origin xyz="${cliff_center_x} ${- cliff_center_y} ${cliff_z + base_link_z_offset}"
             rpy="0 ${cliff_center_pitch} ${- cliff_center_yaw}"/>
   </xacro:cliff_sensor>
@@ -152,25 +164,25 @@
             left                                    front_right
   side_left                                                   right
   -->
-  <xacro:ir_intensity name="front_center_left">
+  <xacro:ir_intensity name="front_center_left" gazebo="$(arg gazebo)">
     <origin xyz="0.1540 0 ${ir_intensity_z_pos + base_link_z_offset}"/>
   </xacro:ir_intensity>
-  <xacro:ir_intensity name="front_center_right">
+  <xacro:ir_intensity name="front_center_right" gazebo="$(arg gazebo)">
     <origin xyz="0.1396 -0.0651 ${ir_intensity_z_pos + base_link_z_offset}" rpy="0 0 -0.436"/>
   </xacro:ir_intensity>
-  <xacro:ir_intensity name="front_left">
+  <xacro:ir_intensity name="front_left" gazebo="$(arg gazebo)">
     <origin xyz="0.1396 0.0651 ${ir_intensity_z_pos + base_link_z_offset}" rpy="0 0 0.436"/>
   </xacro:ir_intensity>
-  <xacro:ir_intensity name="front_right">
+  <xacro:ir_intensity name="front_right" gazebo="$(arg gazebo)">
     <origin xyz="0.0990 -0.1180 ${ir_intensity_z_pos + base_link_z_offset}" rpy="0 0 -0.873"/>
   </xacro:ir_intensity>
-  <xacro:ir_intensity name="left">
+  <xacro:ir_intensity name="left" gazebo="$(arg gazebo)">
     <origin xyz="0.0990 0.1180 ${ir_intensity_z_pos + base_link_z_offset}" rpy="0 0 0.873"/>
   </xacro:ir_intensity>
-  <xacro:ir_intensity name="right">
+  <xacro:ir_intensity name="right" gazebo="$(arg gazebo)">
     <origin xyz="0.0399 -0.1488 ${ir_intensity_z_pos + base_link_z_offset}" rpy="0 0 -1.309"/>
   </xacro:ir_intensity>
-  <xacro:ir_intensity name="side_left">
+  <xacro:ir_intensity name="side_left" gazebo="$(arg gazebo)">
     <origin xyz="0.0399 0.1488 ${ir_intensity_z_pos + base_link_z_offset}" rpy="0 0 1.309"/>
   </xacro:ir_intensity>
 
@@ -191,41 +203,88 @@
   <!-- Omni IR receiver (sensor 0) parameters and Front-facing IR receiver (sensor 1) parameters -->
   <xacro:property name="ir_omni_fov_rad" value="${220.0*deg2rad}"/>
   <xacro:property name="ir_front_facing_fov_rad" value="${pi/2}"/>
-  <xacro:ir_opcode_receivers robot_model_name="${robot_model_name}" dock_model_name="${dock_model_name}"
+  <xacro:ir_opcode_receivers gazebo="$(arg gazebo)" robot_model_name="${robot_model_name}" dock_model_name="${dock_model_name}"
     emitter_link_name="${emitter_link_name}" sensor_0_range="0.01" sensor_0_fov="${ir_omni_fov_rad}"
     sensor_1_range="0.5" sensor_1_fov="${ir_front_facing_fov_rad}" >
     <origin xyz="0.153 0 ${0.035 + base_link_z_offset}"/>
   </xacro:ir_opcode_receivers>
 
-  <!-- Ground truth pose -->
-  <gazebo>
-    <plugin name="gazebo_ros_p3d_robot" filename="libgazebo_ros_p3d.so">
-      <ros>
-        <namespace>/</namespace>
-        <remapping>odom:=sim_ground_truth_pose</remapping>
-      </ros>
-      <body_name>base_link</body_name>
-      <frame_name>world</frame_name>
-      <update_rate>62</update_rate>
-      <xyz_offset>0 0 0</xyz_offset>
-      <rpy_offset>0.0 0.0 0.0</rpy_offset>
-      <gaussian_noise>0.0</gaussian_noise>
-    </plugin>
-  </gazebo>
+  <!-- Plugins -->
+  <xacro:if value="${'$(arg gazebo)' == 'classic'}">
+    <!-- Ground truth pose -->
+    <gazebo>
+      <plugin name="gazebo_ros_p3d_robot" filename="libgazebo_ros_p3d.so">
+        <ros>
+          <namespace>/</namespace>
+          <remapping>odom:=sim_ground_truth_pose</remapping>
+        </ros>
+        <body_name>base_link</body_name>
+        <frame_name>world</frame_name>
+        <update_rate>62</update_rate>
+        <xyz_offset>0 0 0</xyz_offset>
+        <rpy_offset>0.0 0.0 0.0</rpy_offset>
+        <gaussian_noise>0.0</gaussian_noise>
+      </plugin>
+    </gazebo>
 
-  <!-- Dock status -->
-  <gazebo>
-    <plugin name="dock_status_publisher" filename="libgazebo_ros_create_docking_status.so">
-      <ros>
-        <namespace>/</namespace>
-        <remapping>~/out:=dock</remapping>
-      </ros>
-      <update_rate>1.0</update_rate>
-      <robot_model_name>${robot_model_name}</robot_model_name>
-      <receiver_link_name>${receiver_link_name}</receiver_link_name>
-      <dock_model_name>${dock_model_name}</dock_model_name>
-      <emitter_link_name>${emitter_link_name}</emitter_link_name>
-    </plugin>
-  </gazebo>
+    <!-- Dock status -->
+    <gazebo>
+      <plugin name="dock_status_publisher" filename="libgazebo_ros_create_docking_status.so">
+        <ros>
+          <namespace>/</namespace>
+          <remapping>~/out:=dock</remapping>
+        </ros>
+        <update_rate>1.0</update_rate>
+        <robot_model_name>${robot_model_name}</robot_model_name>
+        <receiver_link_name>${receiver_link_name}</receiver_link_name>
+        <dock_model_name>${dock_model_name}</dock_model_name>
+        <emitter_link_name>${emitter_link_name}</emitter_link_name>
+      </plugin>
+    </gazebo>
+  </xacro:if>
+
+  <xacro:if value="${'$(arg gazebo)' == 'ignition'}">
+    <gazebo>
+      <plugin filename="libignition-gazebo-pose-publisher-system.so" name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>true</publish_link_pose>
+        <publish_nested_model_pose>true</publish_nested_model_pose>
+        <use_pose_vector_msg>true</use_pose_vector_msg>
+        <update_frequency>62</update_frequency>
+      </plugin>
+    </gazebo>
+  
+    <gazebo>
+      <plugin filename="libignition-gazebo-joint-state-publisher-system.so" name="ignition::gazebo::systems::JointStatePublisher">
+        <joint_name>wheel_drop_left_joint</joint_name>
+        <joint_name>wheel_drop_right_joint</joint_name>
+        <joint_name>left_wheel_joint</joint_name>
+        <joint_name>right_wheel_joint</joint_name>
+      </plugin>
+    </gazebo>
+  
+    <gazebo>
+      <plugin filename="ignition-gazebo-diff-drive-system" name="ignition::gazebo::systems::DiffDrive">
+        <left_joint>left_wheel_joint</left_joint>
+        <right_joint>right_wheel_joint</right_joint>
+        <wheel_separation>0.233</wheel_separation>
+        <wheel_radius>0.03575</wheel_radius>
+        <frame_id>odom</frame_id>
+        <child_frame_id>base_link</child_frame_id>
+        <odom_publish_frequency>50</odom_publish_frequency>
+        <min_acceleration>-1</min_acceleration>
+        <max_acceleration>1</max_acceleration>
+      </plugin>
+    </gazebo>
+  
+    <gazebo>
+      <plugin filename="libignition-gazebo-contact-system.so" name="ignition::gazebo::systems::Contact"></plugin>
+    </gazebo>
+      
+    <gazebo>
+      <plugin filename="libignition-gazebo-sensors-system.so" name="ignition::gazebo::systems::Sensors">
+        <render_engine>ogre</render_engine>
+      </plugin>
+    </gazebo>
+  </xacro:if>
 
 </robot>

--- a/irobot_create_description/urdf/dock/ir_emitter.urdf.xacro
+++ b/irobot_create_description/urdf/dock/ir_emitter.urdf.xacro
@@ -1,11 +1,12 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:macro name="ir_emitter" params="name parent:=base_link *origin
+                                         gazebo
                                          range
                                          aperture
                                          update_rate:=1.0
                                          min_range:=${7*cm2m}
-                                         visualize:=false" >
+                                         visualize:=true" >
 
     <!-- Physical link properties -->
     <xacro:property name="mass" value="0.15" />
@@ -27,26 +28,12 @@
     only when the visualize flag is set. No need for high update rates. -->
     <xacro:if value="${visualize}">
       <gazebo reference="${name}_link">
-        <sensor type="ray" name="${name}">
-          <always_on>true</always_on>
-          <update_rate>${update_rate}</update_rate>
-          <visualize>${visualize}</visualize>
-          <ray>
-            <scan>
-              <horizontal>
-                <samples>50</samples>
-                <resolution>1</resolution>
-                <min_angle>-${aperture/2}</min_angle>
-                <max_angle>${aperture/2}</max_angle>
-                </horizontal>
-            </scan>
-              <range>
-              <min>${min_range}</min>
-              <max>${range}</max>
-              <resolution>0.01</resolution>
-            </range>
-          </ray>
-        </sensor>
+        <xacro:ray_sensor sensor_name="${name}" gazebo="${gazebo}" 
+                      update_rate="${update_rate}" visualize="${visualize}" 
+                      h_samples="50" h_res="1.0" h_min_angle="-${aperture/2}" h_max_angle="${aperture/2}" 
+                      r_min="${min_range}" r_max="${range}" r_res="0.01">
+                      <plugin name="dummy" filename="dummyfile"></plugin>
+        </xacro:ray_sensor>
       </gazebo>
     </xacro:if>
 

--- a/irobot_create_description/urdf/dock/standard_dock.urdf.xacro
+++ b/irobot_create_description/urdf/dock/standard_dock.urdf.xacro
@@ -3,6 +3,9 @@
   <xacro:include filename="$(find irobot_create_description)/urdf/common_properties.urdf.xacro"/>
   <xacro:include filename="$(find irobot_create_description)/urdf/dock/ir_emitter.urdf.xacro"/>
 
+  <!-- Gazebo version -->
+  <xacro:arg name="gazebo"         default="classic" />
+
   <xacro:property name="z_offset"  value="${4.6*mm2m}"/>
   <xacro:property name="link_name" value="std_dock_link"/>
 
@@ -38,6 +41,7 @@
   <!-- Green IR emitter -->
   <xacro:ir_emitter name="${green_buoy_name}"
                     parent="${link_name}"
+                    gazebo="$(arg gazebo)"
                     aperture="${buoy_lateral_aperture}"
                     range="1.0">
     <origin xyz="${buoy_x} 0 ${buoy_z}"
@@ -47,6 +51,7 @@
   <!-- Red IR emitter -->
   <xacro:ir_emitter name="${red_buoy_name}"
                     parent="${link_name}"
+                    gazebo="$(arg gazebo)"
                     aperture="${buoy_lateral_aperture}"
                     range="1.0">
     <origin xyz="${buoy_x} 0 ${buoy_z}"
@@ -56,6 +61,7 @@
   <!-- Yellow IR emitter -->
   <xacro:ir_emitter name="${yellow_buoy_name}"
                     parent="${link_name}"
+                    gazebo="$(arg gazebo)"
                     aperture="${10*deg2rad}"
                     range="1.0">
     <origin xyz="${buoy_x} 0 ${buoy_z}"/>
@@ -64,26 +70,42 @@
   <!-- Halo IR emitter -->
   <xacro:ir_emitter name="${halo_name}"
                     parent="${link_name}"
+                    gazebo="$(arg gazebo)"
                     aperture="360"
                     range="0.6096">
     <origin xyz="${buoy_x} 0 ${0.095 - z_offset}"/>
   </xacro:ir_emitter>
 
-  <gazebo>
-    <static>true</static>
-    <!-- Ground truth pose-->
-    <plugin name="gazebo_ros_p3d_dock" filename="libgazebo_ros_p3d.so">
-      <ros>
-        <namespace>/</namespace>
-        <remapping>odom:=sim_ground_truth_dock_pose</remapping>
-      </ros>
-      <body_name>${link_name}</body_name>
-      <frame_name>world</frame_name>
-      <update_rate>1</update_rate>
-      <xyz_offset>0 0 0</xyz_offset>
-      <rpy_offset>0.0 0.0 0.0</rpy_offset>
-      <gaussian_noise>0.0</gaussian_noise>
-    </plugin>
-  </gazebo>
+  <xacro:if value="${'$(arg gazebo)' == 'classic'}">
+    <gazebo>
+      <static>true</static>
+      <!-- Ground truth pose-->
+      <plugin name="gazebo_ros_p3d_dock" filename="libgazebo_ros_p3d.so">
+        <ros>
+          <namespace>/</namespace>
+          <remapping>odom:=sim_ground_truth_dock_pose</remapping>
+        </ros>
+        <body_name>${link_name}</body_name>
+        <frame_name>world</frame_name>
+        <update_rate>1</update_rate>
+        <xyz_offset>0 0 0</xyz_offset>
+        <rpy_offset>0.0 0.0 0.0</rpy_offset>
+        <gaussian_noise>0.0</gaussian_noise>
+      </plugin>
+    </gazebo>
+  </xacro:if>
+
+  <xacro:if value="${'$(arg gazebo)' == 'ignition'}">
+    <gazebo>
+      <static>true</static>
+      <!-- Ground truth pose-->
+      <plugin filename="libignition-gazebo-pose-publisher-system.so" name="ignition::gazebo::systems::PosePublisher">
+        <publish_link_pose>true</publish_link_pose>
+        <publish_nested_model_pose>true</publish_nested_model_pose>   
+        <use_pose_vector_msg>true</use_pose_vector_msg>   
+        <update_frequency>62</update_frequency>
+      </plugin>
+    </gazebo>
+  </xacro:if>
 
 </robot>

--- a/irobot_create_description/urdf/sensors/cliff_sensor.urdf.xacro
+++ b/irobot_create_description/urdf/sensors/cliff_sensor.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-<xacro:macro name="cliff_sensor" params="name parent:=base_link
+<xacro:macro name="cliff_sensor" params="name gazebo parent:=base_link
                                          visualize:=false *origin">
   <!-- Sensor settings -->
   <xacro:property name="update_rate"         value="62"/>
@@ -25,31 +25,10 @@
   </link>
 
   <gazebo reference="${sensor_name}">
-    <sensor type="ray" name="${sensor_name}">
-      <update_rate>${update_rate}</update_rate>
-      <visualize>${visualize}</visualize>
-      <always_on>true</always_on>
-      <ray>
-        <scan>
-          <horizontal>
-            <samples>${samples}</samples>
-            <resolution>1.0</resolution>
-            <min_angle>-${fov_rad/2}</min_angle>
-            <max_angle>${fov_rad/2}</max_angle>
-          </horizontal>
-        </scan>
-        <range>
-          <min>${min_range}</min>
-          <max>${max_range}</max>
-          <resolution>1.0</resolution>
-        </range>
-      </ray>
-      <!-- Noise is currently disabled -->
-      <noise>
-        <type>gaussian</type>
-        <mean>0.0</mean>
-        <stddev>0.0</stddev>
-      </noise>
+    <xacro:ray_sensor sensor_name="${sensor_name}" gazebo="${gazebo}" 
+                      update_rate="${update_rate}" visualize="${visualize}" 
+                      h_samples="${samples}" h_res="1.0" h_min_angle="-${fov_rad/2}" h_max_angle="${fov_rad/2}" 
+                      r_min="${min_range}" r_max="${max_range}" r_res="1.0">
       <plugin name="${sensor_name}" filename="libgazebo_ros_create_cliff_sensor.so">
         <ros>
           <namespace>/</namespace>
@@ -58,7 +37,7 @@
         <detection_threshold>${detection_threshold}</detection_threshold>
         <frame_id>${sensor_name}</frame_id>
       </plugin>
-    </sensor>
+    </xacro:ray_sensor>
   </gazebo>
 </xacro:macro>
 

--- a/irobot_create_description/urdf/sensors/imu.urdf.xacro
+++ b/irobot_create_description/urdf/sensors/imu.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-<xacro:macro name="imu_sensor" params="name:=imu parent:=base_link update_rate:=62 *origin">
+<xacro:macro name="imu_sensor" params="name:=imu gazebo parent:=base_link update_rate:=62 *origin">
 
   <joint name="${name}_joint" type="fixed">
     <xacro:insert_block name="origin"/>
@@ -59,12 +59,14 @@
           </z>
         </linear_acceleration>
       </imu>
-      <plugin name="${name}_plugin" filename="libgazebo_ros_create_imu.so">
-        <ros>
-          <namespace>/</namespace>
-          <remapping>~/out:=imu</remapping>
-        </ros>
-      </plugin>
+      <xacro:if value="${gazebo == 'classic'}">
+        <plugin name="${name}_plugin" filename="libgazebo_ros_create_imu.so">
+          <ros>
+            <namespace>/</namespace>
+            <remapping>~/out:=imu</remapping>
+          </ros>
+        </plugin>
+      </xacro:if>
     </sensor>
   </gazebo>
 

--- a/irobot_create_description/urdf/sensors/ir_intensity.urdf.xacro
+++ b/irobot_create_description/urdf/sensors/ir_intensity.urdf.xacro
@@ -3,7 +3,7 @@
   <xacro:include filename="$(find irobot_create_description)/urdf/common_properties.urdf.xacro"/>
 
   <xacro:macro name="ir_intensity"
-               params="name parent:=base_link
+               params="name gazebo parent:=base_link
                        update_rate:=62.0 fov:=${10*deg2rad}
                        min_range:=${25*mm2m} max_range:=${200*mm2m}
                        visualize:=false *origin" >
@@ -25,44 +25,18 @@
     </gazebo>
 
     <gazebo reference="${link_name}">
-      <sensor type="ray" name="${link_name}">
-        <always_on>1</always_on>
-        <update_rate>${update_rate}</update_rate>
-        <visualize>${visualize}</visualize>
-        <ray>
-          <scan>
-            <horizontal>
-              <samples>5</samples>
-              <resolution>1</resolution>
-              <min_angle>-${fov/2}</min_angle>
-              <max_angle>${fov/2}</max_angle>
-            </horizontal>
-            <vertical>
-              <samples>5</samples>
-              <resolution>1</resolution>
-              <min_angle>-${fov/2}</min_angle>
-              <max_angle>${fov/2}</max_angle>
-            </vertical>
-          </scan>
-          <range>
-            <min>${min_range}</min>
-            <max>${max_range}</max>
-            <resolution>0.01</resolution>
-          </range>
-        </ray>
-        <!-- Noise is currently disabled -->
-        <noise>
-          <type>gaussian</type>
-          <mean>0.0</mean>
-          <stddev>0.0</stddev>
-        </noise>
-        <plugin filename="libgazebo_ros_create_ir_intensity_sensor.so" name="${link_name}">
-          <ros>
-            <namespace>/</namespace>
-            <remapping>~/out:=_internal/${link_name}</remapping>
-          </ros>
-        </plugin>
-      </sensor>
+      <xacro:ray_sensor sensor_name="${link_name}" gazebo="${gazebo}" 
+                      update_rate="${update_rate}" visualize="${visualize}" 
+                      h_samples="5" h_res="1.0" h_min_angle="-${fov/2}" h_max_angle="${fov/2}"
+                      v_samples="5" v_res="1.0" v_min_angle="-${fov/2}" v_max_angle="${fov/2}" 
+                      r_min="${min_range}" r_max="${max_range}" r_res="1.0">
+          <plugin filename="libgazebo_ros_create_ir_intensity_sensor.so" name="${link_name}">
+            <ros>
+              <namespace>/</namespace>
+              <remapping>~/out:=_internal/${link_name}</remapping>
+            </ros>
+          </plugin>
+      </xacro:ray_sensor>
     </gazebo>
   </xacro:macro>
 </robot>

--- a/irobot_create_description/urdf/sensors/ir_opcode_receivers.urdf.xacro
+++ b/irobot_create_description/urdf/sensors/ir_opcode_receivers.urdf.xacro
@@ -3,6 +3,7 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
   <xacro:macro name="ir_opcode_receivers" params="name:=ir_omni
+                                                  gazebo
                                                   robot_model_name
                                                   dock_model_name
                                                   emitter_link_name
@@ -35,70 +36,44 @@
     <xacro:if value="${visualize}">
       <!-- Sensor 0 visualization -->
       <gazebo reference="${receiver_link_name}">
-        <sensor type="ray" name="sensor_0">
-            <always_on>true</always_on>
-            <update_rate>1</update_rate>
-            <visualize>${visualize}</visualize>
-            <ray>
-                <scan>
-                    <horizontal>
-                        <samples>${samples}</samples>
-                        <resolution>1</resolution>
-                        <min_angle>${-sensor_0_fov/2}</min_angle>
-                        <max_angle>${sensor_0_fov/2}</max_angle>
-                    </horizontal>
-                </scan>
-                <range>
-                    <min>${min_range}</min>
-                    <max>${sensor_0_range}</max>
-                    <resolution>0.01</resolution>
-                </range>
-            </ray>
-        </sensor>
+        <xacro:ray_sensor sensor_name="sensor_0" gazebo="${gazebo}" 
+                      update_rate="1" visualize="${visualize}" 
+                      h_samples="${samples}" h_res="1.0" h_min_angle="-${sensor_0_fov/2}" h_max_angle="${sensor_0_fov/2}" 
+                      r_min="${min_range}" r_max="${sensor_0_range}" r_res="0.01">
+                      <plugin name="dummy" filename="dummyfile"></plugin>
+        </xacro:ray_sensor>
       </gazebo>
 
       <!-- Sensor 1 visualization -->
       <gazebo reference="${receiver_link_name}">
-        <sensor type="ray" name="sensor_1">
-            <always_on>true</always_on>
-            <update_rate>1</update_rate>
-            <visualize>${visualize}</visualize>
-            <ray>
-                <scan>
-                    <horizontal>
-                        <samples>${samples}</samples>
-                        <resolution>1</resolution>
-                        <min_angle>${-sensor_1_fov/2}</min_angle>
-                        <max_angle>${sensor_1_fov/2}</max_angle>
-                    </horizontal>
-                </scan>
-                <range>
-                    <min>${min_range}</min>
-                    <max>${sensor_1_range}</max>
-                    <resolution>0.01</resolution>
-                </range>
-            </ray>
-        </sensor>
+        <xacro:ray_sensor sensor_name="sensor_1" gazebo="${gazebo}" 
+                      update_rate="1" visualize="${visualize}" 
+                      h_samples="${samples}" h_res="1.0" h_min_angle="-${sensor_1_fov/2}" h_max_angle="${sensor_1_fov/2}" 
+                      r_min="${min_range}" r_max="${sensor_1_range}" r_res="0.01">
+                      <plugin name="dummy" filename="dummyfile"></plugin>
+        </xacro:ray_sensor>
       </gazebo>
     </xacro:if>
 
-    <gazebo>
-      <plugin name="${name}_plugin" filename="libgazebo_ros_create_ir_opcode.so">
-        <ros>
-          <namespace>/</namespace>
-          <remapping>~/out:=ir_opcode</remapping>
-        </ros>
-        <update_rate>${update_rate}</update_rate>
-        <robot_model_name>${robot_model_name}</robot_model_name>
-        <receiver_link_name>${receiver_link_name}</receiver_link_name>
-        <dock_model_name>${dock_model_name}</dock_model_name>
-        <emitter_link_name>${emitter_link_name}</emitter_link_name>
-        <sensor_0_fov>${sensor_0_fov}</sensor_0_fov>
-        <sensor_0_range>${sensor_0_range}</sensor_0_range>
-        <sensor_1_fov>${sensor_1_fov}</sensor_1_fov>
-        <sensor_1_range>${sensor_1_range}</sensor_1_range>
-      </plugin>
-    </gazebo>
+    <xacro:if value="${gazebo == 'classic'}">
+      <gazebo>
+        <plugin name="${name}_plugin" filename="libgazebo_ros_create_ir_opcode.so">
+          <ros>
+            <namespace>/</namespace>
+            <remapping>~/out:=ir_opcode</remapping>
+          </ros>
+          <update_rate>${update_rate}</update_rate>
+          <robot_model_name>${robot_model_name}</robot_model_name>
+          <receiver_link_name>${receiver_link_name}</receiver_link_name>
+          <dock_model_name>${dock_model_name}</dock_model_name>
+          <emitter_link_name>${emitter_link_name}</emitter_link_name>
+          <sensor_0_fov>${sensor_0_fov}</sensor_0_fov>
+          <sensor_0_range>${sensor_0_range}</sensor_0_range>
+          <sensor_1_fov>${sensor_1_fov}</sensor_1_fov>
+          <sensor_1_range>${sensor_1_range}</sensor_1_range>
+        </plugin>
+      </gazebo>
+    </xacro:if>
 
     <gazebo reference="${joint_name}" >
       <preserveFixedJoint>true</preserveFixedJoint>

--- a/irobot_create_description/urdf/sensors/optical_mouse.urdf.xacro
+++ b/irobot_create_description/urdf/sensors/optical_mouse.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:macro name="optical_mouse" params="name:=mouse parent_link:=base_link update_rate:=62 *origin" >
+  <xacro:macro name="optical_mouse" params="name:=mouse gazebo parent_link:=base_link update_rate:=62 *origin" >
 
     <joint name="${name}_joint" type="fixed">
       <xacro:insert_block name="origin"/>
@@ -13,17 +13,19 @@
       <xacro:inertial_dummy />
     </link>
 
-    <gazebo>
-      <plugin name="${name}_plugin" filename="libgazebo_ros_create_optical_mouse.so">
-          <ros>
-            <namespace>/</namespace>
-            <remapping>~/out:=${name}</remapping>
-          </ros>
-        <update_rate>${update_rate}</update_rate>
-        <link_name>${name}</link_name>
-      </plugin>
-    </gazebo>
-
+    <xacro:if value="${gazebo == 'classic'}">
+      <gazebo>
+        <plugin name="${name}_plugin" filename="libgazebo_ros_create_optical_mouse.so">
+            <ros>
+              <namespace>/</namespace>
+              <remapping>~/out:=${name}</remapping>
+            </ros>
+          <update_rate>${update_rate}</update_rate>
+          <link_name>${name}</link_name>
+        </plugin>
+      </gazebo>
+    </xacro:if>
+    
     <gazebo reference="${name}_joint" >
       <preserveFixedJoint>true</preserveFixedJoint>
     </gazebo>

--- a/irobot_create_description/urdf/wheel.urdf.xacro
+++ b/irobot_create_description/urdf/wheel.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-<xacro:macro name="wheel" params="name parent_link *origin">
+<xacro:macro name="wheel" params="name gazebo parent_link *origin">
 
   <xacro:property name="mass"   value="0.2" />
   <xacro:property name="radius" value="${3.575*cm2m}" />
@@ -44,16 +44,18 @@
     <material>Gazebo/DarkGrey</material>
   </gazebo>
 
-  <ros2_control name="${wheel_link_name}_controller" type="system">
-    <hardware>
-      <plugin>gazebo_ros2_control/GazeboSystem</plugin>
-    </hardware>
-    <joint name="${wheel_joint_name}">
-      <state_interface name="velocity" />
-      <state_interface name="position" />
-      <command_interface name="velocity" />
-    </joint>
-  </ros2_control>
+  <xacro:if value="${gazebo == 'classic'}">
+    <ros2_control name="${wheel_link_name}_controller" type="system">
+      <hardware>
+        <plugin>gazebo_ros2_control/GazeboSystem</plugin>
+      </hardware>
+      <joint name="${wheel_joint_name}">
+        <state_interface name="velocity" />
+        <state_interface name="position" />
+        <command_interface name="velocity" />
+      </joint>
+    </ros2_control>
+  </xacro:if>
 
 </xacro:macro>
 </robot>

--- a/irobot_create_description/urdf/wheel_drop.urdf.xacro
+++ b/irobot_create_description/urdf/wheel_drop.urdf.xacro
@@ -1,11 +1,22 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-<xacro:macro name="wheel_drop" params="name parent_link *origin" >
+<xacro:macro name="wheel_drop" params="name gazebo parent_link *origin" >
   <xacro:include filename="$(find irobot_create_description)/urdf/common_properties.urdf.xacro"/>
 
   <xacro:property name="detection_threshold" value="${3*cm2m}"/>
-  <xacro:property name="spring_stiffness_nm" value="450"/>
 
+  <xacro:if value="${gazebo == 'classic'}">
+    <xacro:property name="spring_stiffness_nm"  value="400"/>
+    <xacro:property name="spring_damping"       value="50"/>
+    <xacro:property name="spring_friction"      value="0.1"/>
+  </xacro:if>
+
+  <xacro:if value="${gazebo == 'ignition'}">
+    <xacro:property name="spring_stiffness_nm"  value="450"/>
+    <xacro:property name="spring_damping"       value="50"/>
+    <xacro:property name="spring_friction"      value="0.1"/>
+  </xacro:if>
+  
   <xacro:property name="wd_size" value="${5*cm2m}"/>
   <xacro:property name="wd_mass" value="0.05"/>
 
@@ -19,8 +30,8 @@
     <xacro:insert_block name="origin"/>
     <axis xyz="0 1 0"/>
     <limit lower="0" upper="${detection_threshold}" effort="0" velocity="0"/>
-    <!-- Damping is big enough to don't make the body oscillate too much when it's lifted up -->
-    <dynamics damping="50" friction="0.1"/>
+    <!-- Damping is big enough to not make the body oscillate too much when it's lifted up -->
+    <dynamics damping="${spring_damping}" friction="${spring_friction}"/>
   </joint>
 
   <!-- Gazebo parameters to simulate a spring -->
@@ -37,18 +48,20 @@
     <xacro:inertial_cuboid mass="${wd_mass}" x="${wd_size}" y="${wd_size}" z="${wd_size}"/>
   </link>
 
-  <gazebo>
-    <plugin name="${wd_link_name}_plugin" filename="libgazebo_ros_create_wheel_drop.so">
-      <ros>
-        <namespace>/</namespace>
-        <remapping>~/out:=_internal/wheel_drop/${name}_wheel/event</remapping>
-      </ros>
-      <update_rate>${update_rate}</update_rate>
-      <detection_threshold>${detection_threshold}</detection_threshold>
-      <joint_name>${wd_joint_name}</joint_name>
-      <frame_id>${wd_link_name}</frame_id>
-    </plugin>
-  </gazebo>
+  <xacro:if value="${gazebo == 'classic'}">
+    <gazebo>
+      <plugin name="${wd_link_name}_plugin" filename="libgazebo_ros_create_wheel_drop.so">
+        <ros>
+          <namespace>/</namespace>
+          <remapping>~/out:=_internal/wheel_drop/${name}_wheel/event</remapping>
+        </ros>
+        <update_rate>${update_rate}</update_rate>
+        <detection_threshold>${detection_threshold}</detection_threshold>
+        <joint_name>${wd_joint_name}</joint_name>
+        <frame_id>${wd_link_name}</frame_id>
+      </plugin>
+    </gazebo>
+  </xacro:if>
 
 </xacro:macro>
 </robot>

--- a/irobot_create_description/urdf/wheel_with_wheeldrop.urdf.xacro
+++ b/irobot_create_description/urdf/wheel_with_wheeldrop.urdf.xacro
@@ -1,17 +1,17 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-<xacro:macro name="wheel_with_wheeldrop" params="name parent_link:=base_link *origin">
+<xacro:macro name="wheel_with_wheeldrop" params="name gazebo parent_link:=base_link *origin">
   <xacro:include filename="$(find irobot_create_description)/urdf/wheel.urdf.xacro" />
   <xacro:include filename="$(find irobot_create_description)/urdf/wheel_drop.urdf.xacro" />
 
   <!-- Wheel Drop definition -->
-  <xacro:wheel_drop name="${name}" parent_link="${parent_link}">
+  <xacro:wheel_drop name="${name}" gazebo="${gazebo}" parent_link="${parent_link}">
     <xacro:insert_block name="origin"/>
   </xacro:wheel_drop>
 
   <!-- Wheel definition -->
-  <xacro:wheel name="${name}" parent_link="wheel_drop_${name}">
+  <xacro:wheel name="${name}" gazebo="${gazebo}" parent_link="wheel_drop_${name}">
     <origin xyz="0 0 0" rpy="0 0 0"/>
   </xacro:wheel>
 


### PR DESCRIPTION
## Description

- Added gazebo arg to create3.urdf.xacro and standard_dock.urdf.xacro. This arg sets which gazebo version to use.
- Added ray sensor macro which creates the correct sensor given the gazebo arg
- Added ignition plugins when gazebo=ignition
- Adjusted front caster position to better align with the create3 model
- Adjusted wheeldrop spring stiffness to compensate for the front caster position change

Fixes #137

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Also list any relevant details for your test configuration.

```bash
# Run this command
ros2 launch irobot_create_gazebo_bringup create3_gazebo.launch.py 
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
