### PR TITLE
Add Launch arguments to enable/disable visualization of rays

### DIFF
--- a/irobot_create_common_bringup/launch/dock_description.launch.py
+++ b/irobot_create_common_bringup/launch/dock_description.launch.py
@@ -46,7 +46,10 @@ def generate_launch_description():
         parameters=[
             {'use_sim_time': True},
             {'robot_description':
-             Command(['xacro', ' ', dock_xacro_file, ' ', 'gazebo:=', gazebo_simulator, ' ', 'visualize_rays:=', visualize_rays])},
+             Command(
+                ['xacro', ' ', dock_xacro_file, ' ',
+                 'gazebo:=', gazebo_simulator, ' ',
+                 'visualize_rays:=', visualize_rays])},
         ],
         remappings=[
             ('robot_description', 'standard_dock_description'),

--- a/irobot_create_common_bringup/launch/dock_description.launch.py
+++ b/irobot_create_common_bringup/launch/dock_description.launch.py
@@ -26,15 +26,13 @@ ARGUMENTS.append(DeclareLaunchArgument('visualize_rays', default_value='true',
 
 def generate_launch_description():
     # Directory
-    pkg_create3_description = get_package_share_directory(
-        'irobot_create_description')
+    pkg_create3_description = get_package_share_directory('irobot_create_description')
     # Path
     dock_xacro_file = PathJoinSubstitution(
         [pkg_create3_description, 'urdf', 'dock', 'standard_dock.urdf.xacro'])
 
     # Launch Configurations
-    x, y, z = LaunchConfiguration('x'), LaunchConfiguration(
-        'y'), LaunchConfiguration('z')
+    x, y, z = LaunchConfiguration('x'), LaunchConfiguration('y'), LaunchConfiguration('z')
     yaw = LaunchConfiguration('yaw')
     visualize_rays = LaunchConfiguration('visualize_rays')
 

--- a/irobot_create_common_bringup/launch/dock_description.launch.py
+++ b/irobot_create_common_bringup/launch/dock_description.launch.py
@@ -19,17 +19,24 @@ for pose_element in ['x', 'y', 'z', 'yaw']:
     ARGUMENTS.append(DeclareLaunchArgument(f'{pose_element}', default_value='0.0',
                      description=f'{pose_element} component of the dock pose.'))
 
+ARGUMENTS.append(DeclareLaunchArgument('visualize_rays', default_value='true',
+                                       choices=['true', 'false'],
+                                       description='Enable/disable ray visualization'))
+
 
 def generate_launch_description():
     # Directory
-    pkg_create3_description = get_package_share_directory('irobot_create_description')
+    pkg_create3_description = get_package_share_directory(
+        'irobot_create_description')
     # Path
     dock_xacro_file = PathJoinSubstitution(
         [pkg_create3_description, 'urdf', 'dock', 'standard_dock.urdf.xacro'])
 
     # Launch Configurations
-    x, y, z = LaunchConfiguration('x'), LaunchConfiguration('y'), LaunchConfiguration('z')
+    x, y, z = LaunchConfiguration('x'), LaunchConfiguration(
+        'y'), LaunchConfiguration('z')
     yaw = LaunchConfiguration('yaw')
+    visualize_rays = LaunchConfiguration('visualize_rays')
 
     gazebo_simulator = LaunchConfiguration('gazebo')
 
@@ -41,7 +48,7 @@ def generate_launch_description():
         parameters=[
             {'use_sim_time': True},
             {'robot_description':
-             Command(['xacro', ' ', dock_xacro_file, ' ', 'gazebo:=', gazebo_simulator])},
+             Command(['xacro', ' ', dock_xacro_file, ' ', 'gazebo:=', gazebo_simulator, ' ', 'visualize_rays:=', visualize_rays])},
         ],
         remappings=[
             ('robot_description', 'standard_dock_description'),

--- a/irobot_create_common_bringup/launch/robot_description.launch.py
+++ b/irobot_create_common_bringup/launch/robot_description.launch.py
@@ -19,7 +19,6 @@ ARGUMENTS = [
                           description='Enable/disable ray visualization')
 ]
 
-
 def generate_launch_description():
     pkg_create3_description = get_package_share_directory('irobot_create_description')
     xacro_file = PathJoinSubstitution([pkg_create3_description, 'urdf', 'create3.urdf.xacro'])

--- a/irobot_create_common_bringup/launch/robot_description.launch.py
+++ b/irobot_create_common_bringup/launch/robot_description.launch.py
@@ -14,10 +14,11 @@ ARGUMENTS = [
     DeclareLaunchArgument('gazebo', default_value='classic',
                           choices=['classic', 'ignition'],
                           description='Which gazebo simulator to use'),
-	DeclareLaunchArgument('visualize_rays', default_value='false',
+    DeclareLaunchArgument('visualize_rays', default_value='false',
                           choices=['true', 'false'],
                           description='Enable/disable ray visualization')
 ]
+
 
 def generate_launch_description():
     pkg_create3_description = get_package_share_directory('irobot_create_description')
@@ -33,7 +34,10 @@ def generate_launch_description():
         parameters=[
             {'use_sim_time': True},
             {'robot_description':
-             Command(['xacro', ' ', xacro_file, ' ', 'gazebo:=', gazebo_simulator, ' ', 'visualize_rays:=', visualize_rays])},
+             Command(
+                  ['xacro', ' ', xacro_file, ' ',
+                   'gazebo:=', gazebo_simulator, ' ',
+                   'visualize_rays:=', visualize_rays])},
         ],
     )
 

--- a/irobot_create_common_bringup/launch/robot_description.launch.py
+++ b/irobot_create_common_bringup/launch/robot_description.launch.py
@@ -13,7 +13,10 @@ from launch_ros.actions import Node
 ARGUMENTS = [
     DeclareLaunchArgument('gazebo', default_value='classic',
                           choices=['classic', 'ignition'],
-                          description='Which gazebo simulator to use')
+                          description='Which gazebo simulator to use'),
+	DeclareLaunchArgument('visualize_rays', default_value='false',
+                          choices=['true', 'false'],
+                          description='Enable/disable ray visualization')
 ]
 
 
@@ -21,6 +24,7 @@ def generate_launch_description():
     pkg_create3_description = get_package_share_directory('irobot_create_description')
     xacro_file = PathJoinSubstitution([pkg_create3_description, 'urdf', 'create3.urdf.xacro'])
     gazebo_simulator = LaunchConfiguration('gazebo')
+    visualize_rays = LaunchConfiguration('visualize_rays')
 
     robot_state_publisher = Node(
         package='robot_state_publisher',
@@ -30,7 +34,7 @@ def generate_launch_description():
         parameters=[
             {'use_sim_time': True},
             {'robot_description':
-             Command(['xacro', ' ', xacro_file, ' ', 'gazebo:=', gazebo_simulator])},
+             Command(['xacro', ' ', xacro_file, ' ', 'gazebo:=', gazebo_simulator, ' ', 'visualize_rays:=', visualize_rays])},
         ],
     )
 
@@ -43,6 +47,7 @@ def generate_launch_description():
 
     # Define LaunchDescription variable
     ld = LaunchDescription(ARGUMENTS)
+
     # Add nodes to LaunchDescription
     ld.add_action(joint_state_publisher)
     ld.add_action(robot_state_publisher)

--- a/irobot_create_description/urdf/create3.urdf.xacro
+++ b/irobot_create_description/urdf/create3.urdf.xacro
@@ -42,7 +42,7 @@
   <xacro:property name="receiver_link_name" value="ir_omni"/>
   <xacro:property name="dock_model_name" value="standard_dock"/>
   <xacro:property name="emitter_link_name" value="halo_link"/>
-
+  <xacro:arg name="visualize_rays" default="false"/>
   <!-- Create 3 base definition-->
   <link name="base_link">
     <visual>
@@ -127,22 +127,22 @@
   <xacro:property name="cliff_back_pitch" value="${80*deg2rad}"/>
   <xacro:property name="cliff_back_yaw" value="${167.4*deg2rad}"/>
 
-  <xacro:cliff_sensor name="side_left" gazebo="$(arg gazebo)">
+  <xacro:cliff_sensor name="side_left" gazebo="$(arg gazebo)" visualize="$(arg visualize_rays)">
     <origin xyz="${cliff_back_x} ${cliff_back_y} ${cliff_z + base_link_z_offset}"
             rpy="0 ${cliff_back_pitch} ${cliff_back_yaw}"/>
   </xacro:cliff_sensor>
 
-  <xacro:cliff_sensor name="side_right" gazebo="$(arg gazebo)">
+  <xacro:cliff_sensor name="side_right" gazebo="$(arg gazebo)" visualize="$(arg visualize_rays)">
     <origin xyz="${cliff_back_x} ${- cliff_back_y} ${cliff_z + base_link_z_offset}"
             rpy="0 ${cliff_back_pitch} ${- cliff_back_yaw}"/>
   </xacro:cliff_sensor>
 
-  <xacro:cliff_sensor name="front_left" gazebo="$(arg gazebo)">
+  <xacro:cliff_sensor name="front_left" gazebo="$(arg gazebo)" visualize="$(arg visualize_rays)">
     <origin xyz="${cliff_center_x} ${cliff_center_y} ${cliff_z + base_link_z_offset}"
             rpy="0 ${cliff_center_pitch} ${cliff_center_yaw}"/>
   </xacro:cliff_sensor>
 
-  <xacro:cliff_sensor name="front_right" gazebo="$(arg gazebo)">
+  <xacro:cliff_sensor name="front_right" gazebo="$(arg gazebo)" visualize="$(arg visualize_rays)">
     <origin xyz="${cliff_center_x} ${- cliff_center_y} ${cliff_z + base_link_z_offset}"
             rpy="0 ${cliff_center_pitch} ${- cliff_center_yaw}"/>
   </xacro:cliff_sensor>

--- a/irobot_create_description/urdf/dock/standard_dock.urdf.xacro
+++ b/irobot_create_description/urdf/dock/standard_dock.urdf.xacro
@@ -9,6 +9,8 @@
   <xacro:property name="z_offset"  value="${4.6*mm2m}"/>
   <xacro:property name="link_name" value="std_dock_link"/>
 
+  <xacro:arg name="visualize_rays" default="false"/>
+
   <link name="${link_name}">
     <visual>
       <origin xyz="0 0 ${z_offset}"/>
@@ -43,7 +45,8 @@
                     parent="${link_name}"
                     gazebo="$(arg gazebo)"
                     aperture="${buoy_lateral_aperture}"
-                    range="1.0">
+                    range="1.0"
+                    visualize="$(arg visualize_rays)">
     <origin xyz="${buoy_x} 0 ${buoy_z}"
             rpy="0 0 ${- buoy_lateral_angle_yaw}"/>
   </xacro:ir_emitter>
@@ -53,7 +56,8 @@
                     parent="${link_name}"
                     gazebo="$(arg gazebo)"
                     aperture="${buoy_lateral_aperture}"
-                    range="1.0">
+                    range="1.0"
+                    visualize="$(arg visualize_rays)">
     <origin xyz="${buoy_x} 0 ${buoy_z}"
             rpy="0 0 ${buoy_lateral_angle_yaw}"/>
   </xacro:ir_emitter>
@@ -63,7 +67,8 @@
                     parent="${link_name}"
                     gazebo="$(arg gazebo)"
                     aperture="${10*deg2rad}"
-                    range="1.0">
+                    range="1.0"
+                    visualize="$(arg visualize_rays)">
     <origin xyz="${buoy_x} 0 ${buoy_z}"/>
   </xacro:ir_emitter>
 
@@ -72,7 +77,8 @@
                     parent="${link_name}"
                     gazebo="$(arg gazebo)"
                     aperture="360"
-                    range="0.6096">
+                    range="0.6096"
+                    visualize="$(arg visualize_rays)">
     <origin xyz="${buoy_x} 0 ${0.095 - z_offset}"/>
   </xacro:ir_emitter>
 

--- a/irobot_create_gazebo_bringup/launch/create3_gazebo.launch.py
+++ b/irobot_create_gazebo_bringup/launch/create3_gazebo.launch.py
@@ -44,6 +44,9 @@ ARGUMENTS = [
                           description='Spawn the standard dock model.'),
     DeclareLaunchArgument('world_path', default_value='',
                           description='Set world path, by default is empty.world'),
+    DeclareLaunchArgument('visualize_rays', default_value='false',
+                          choices=['true', 'false'],
+                          description='Enable/disable ray visualization'),
 ]
 
 for pose_element in ['x', 'y', 'z', 'yaw']:

--- a/irobot_create_gazebo_bringup/launch/create3_gazebo.launch.py
+++ b/irobot_create_gazebo_bringup/launch/create3_gazebo.launch.py
@@ -44,9 +44,6 @@ ARGUMENTS = [
                           description='Spawn the standard dock model.'),
     DeclareLaunchArgument('world_path', default_value='',
                           description='Set world path, by default is empty.world'),
-    DeclareLaunchArgument('visualize_rays', default_value='false',
-                          choices=['true', 'false'],
-                          description='Enable/disable ray visualization'),
 ]
 
 for pose_element in ['x', 'y', 'z', 'yaw']:


### PR DESCRIPTION
## Description

- Added argument to dock_description.launch.py and robot_description.launch.py to enable/disable the visualization of cliff sensors on the robot and ir_emmiters on the dock.
- Modified create3.urdf.xacro and standard_dock.urdf.zacro to receive arguments.


Fixes #100 .

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

To enable visualization rays, run:
```bash
ros2 launch irobot_create_gazebo_bringup create3_gazebo.launch.py visulize_rays:=true
```
It should look like:
![image](https://user-images.githubusercontent.com/55813299/150850182-c790be13-7844-416e-930e-2972c21d875f.png)
![image](https://user-images.githubusercontent.com/55813299/150850770-de7e444f-7f92-46a0-8454-c575f556ed43.png)

To disable visualization rays, run:
```bash
ros2 launch irobot_create_gazebo_bringup create3_gazebo.launch.py visulize_rays:=false
```
It should look like:
![image](https://user-images.githubusercontent.com/55813299/150849886-d8d5aa15-dc4c-446f-b794-32f297740fa9.png)

## Checklist
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation