### PR TITLE
update codeowners file to make irobot team owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,1 @@
-* @apojomovsky
-* @eborghi10
-* @lchico
-* @rjcausarano
+* @asoragna @jkearns


### PR DESCRIPTION
## Description

Make the iRobot team (Alberto & Justin) codeowners of the repository.
This also fixes a bug where multiple codeowners rules were overwriting each others, resulting in only the last one to be applied


## How Has This Been Tested?

No tests

