### PR TITLE
Fix stderr for kidnap estimator node

### DIFF
--- a/irobot_create_toolbox/src/kidnap_estimator_publisher.cpp
+++ b/irobot_create_toolbox/src/kidnap_estimator_publisher.cpp
@@ -36,14 +36,14 @@ KidnapEstimator::KidnapEstimator()
 
 void KidnapEstimator::kidnap_callback(irobot_create_msgs::msg::HazardDetectionVector::SharedPtr msg)
 {
-  auto hazard_vector = msg->detections;
-  auto wheel_drop_count = std::count_if(
+  const auto hazard_vector = msg->detections;
+  const std::size_t wheel_drop_count = std::count_if(
     hazard_vector.begin(), hazard_vector.end(), [](auto hazard_vector) {
       return hazard_vector.header.frame_id == "wheel_drop_left" ||
       hazard_vector.header.frame_id == "wheel_drop_right";
     });
 
-  auto cliff_sensor_count = std::count_if(
+  const std::size_t cliff_sensor_count = std::count_if(
     hazard_vector.begin(), hazard_vector.end(), [](auto hazard_vector) {
       return hazard_vector.header.frame_id == "cliff_side_left" ||
       hazard_vector.header.frame_id == "cliff_side_right" ||


### PR DESCRIPTION
Signed-off-by: Emiliano Borghi <creativa_eborghi@irobot.com>

## Description

This PR fixes a compilation stderr in the kidnap estimator node introduced in #128.

```
--- stderr: irobot_create_toolbox                                           
/catkin_ws/src/create3_sim/irobot_create_toolbox/src/kidnap_estimator_publisher.cpp: In member function ‘void irobo
t_create_toolbox::KidnapEstimator::kidnap_callback(irobot_create_msgs::msg::HazardDetectionVector_<std::allocator<v
oid> >::SharedPtr)’:       
/catkin_ws/src/create3_sim/irobot_create_toolbox/src/kidnap_estimator_publisher.cpp:58:54: warning: comparison of i
nteger expressions of different signedness: ‘long int’ and ‘const size_t’ {aka ‘const long unsigned int’} [-Wsign-c
ompare]
   58 |   kidnap_status_msg_.is_kidnapped = wheel_drop_count >= min_wheel_drop_count_ &&
      |                                     ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~
/catkin_ws/src/create3_sim/irobot_create_toolbox/src/kidnap_estimator_publisher.cpp:59:24: warning: comparison of i
nteger expressions of different signedness: ‘long int’ and ‘const size_t’ {aka ‘const long unsigned int’} [-Wsign-c
ompare]
   59 |     cliff_sensor_count >= min_cliff_sensor_count_;
      |     ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~ 
---
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Since this is a compilation message, simply compile again:

```bash
colcon build --symlink-install
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
