### PR TITLE
Use ign_ros2_control

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ mkdir -p ~/ignition_ws/src
 ```bash
 cd ~/ignition_ws
 sudo apt-get update && sudo apt-get install wget
-wget https://raw.githubusercontent.com/iRobotEducation/create3_sim/irobot_create_ignition/ignition_edifice.repos
+wget https://raw.githubusercontent.com/iRobotEducation/create3_sim/main/irobot_create_ignition/ignition_edifice.repos
 vcs import ~/ignition_ws/src < ~/ignition_ws/ignition_edifice.repos
 ```
 

--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ rosdep install --from-path src -yi
 - Build the workspace with:
 
 ```bash
+export IGNITION_VERSION=edifice
 colcon build --symlink-install
 source install/local_setup.bash
 ```

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -15,3 +15,7 @@ repositories:
     type: git
     url: https://github.com/iRobotEducation/gazebo_ros2_control.git
     version: create3_galactic
+  ignition-ros2-control:
+    type: git
+    url: https://github.com/ignitionrobotics/ign_ros2_control.git
+    version: galactic

--- a/irobot_create_common/irobot_create_common_bringup/launch/create3_nodes.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/create3_nodes.launch.py
@@ -7,7 +7,6 @@
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
-from launch.conditions import LaunchConfigurationEquals
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
@@ -43,8 +42,7 @@ def generate_launch_description():
 
     # Includes
     diffdrive_controller = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([control_launch_file]),
-        condition=LaunchConfigurationEquals('gazebo', 'classic')
+        PythonLaunchDescriptionSource([control_launch_file])
     )
 
     # Publish hazards vector

--- a/irobot_create_common/irobot_create_control/launch/include/control.py
+++ b/irobot_create_common/irobot_create_control/launch/include/control.py
@@ -21,7 +21,6 @@ def generate_launch_description():
         package='controller_manager',
         executable='spawner',
         parameters=[control_params_file],
-        remappings=[('/diffdrive_controller/cmd_vel_unstamped', '/cmd_vel')],
         arguments=['diffdrive_controller', '-c', '/controller_manager'],
         output='screen',
     )

--- a/irobot_create_common/irobot_create_control/launch/include/control.py
+++ b/irobot_create_common/irobot_create_control/launch/include/control.py
@@ -21,6 +21,7 @@ def generate_launch_description():
         package='controller_manager',
         executable='spawner',
         parameters=[control_params_file],
+        remappings=[('/diffdrive_controller/cmd_vel_unstamped', '/cmd_vel')],
         arguments=['diffdrive_controller', '-c', '/controller_manager'],
         output='screen',
     )

--- a/irobot_create_common/irobot_create_control/package.xml
+++ b/irobot_create_common/irobot_create_control/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <exec_depend>gazebo_ros2_control</exec_depend>
+  <exec_depend>ign_ros2_control</exec_depend>
   <exec_depend>irobot_create_toolbox</exec_depend>
   <exec_depend>joint_state_controller</exec_depend>
   <exec_depend>ros2launch</exec_depend>

--- a/irobot_create_common/irobot_create_description/urdf/create3.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/create3.urdf.xacro
@@ -121,6 +121,14 @@
     </gazebo>
   </xacro:if>
 
+  <xacro:if value="${'$(arg gazebo)' == 'ignition'}">
+    <gazebo>
+      <plugin filename="ign_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin">
+        <parameters> $(find irobot_create_control)/config/control.yaml </parameters>
+      </plugin>
+    </gazebo>
+  </xacro:if>
+
   <!-- Mouse -->
   <xacro:optical_mouse gazebo="$(arg gazebo)">
     <origin xyz="0.1015 0.087 ${-0.055 + base_link_z_offset}" rpy="0 0 ${-pi/4}"/>
@@ -257,44 +265,9 @@
 
   <xacro:if value="${'$(arg gazebo)' == 'ignition'}">
     <gazebo>
-      <plugin filename="libignition-gazebo-pose-publisher-system.so" name="ignition::gazebo::systems::PosePublisher">
-        <publish_link_pose>true</publish_link_pose>
-        <publish_nested_model_pose>true</publish_nested_model_pose>
-        <use_pose_vector_msg>true</use_pose_vector_msg>
-        <update_frequency>62</update_frequency>
-      </plugin>
-    </gazebo>
-  
-    <gazebo>
-      <plugin filename="ignition-gazebo-diff-drive-system" name="ignition::gazebo::systems::DiffDrive">
-        <left_joint>left_wheel_joint</left_joint>
-        <right_joint>right_wheel_joint</right_joint>
-        <wheel_separation>0.233</wheel_separation>
-        <wheel_radius>0.03575</wheel_radius>
-        <frame_id>odom</frame_id>
-        <child_frame_id>base_link</child_frame_id>
-        <odom_publish_frequency>50</odom_publish_frequency>
-        <!-- Requires ignition gazebo to be installed from source -->
-        <min_linear_velocity>-0.46</min_linear_velocity>
-        <max_linear_velocity>0.46</max_linear_velocity>
-        <min_linear_acceleration>-0.9</min_linear_acceleration>
-        <max_linear_acceleration>0.9</max_linear_acceleration>
-        <min_angular_velocity>-1.9</min_angular_velocity>
-        <max_angular_velocity>1.9</max_angular_velocity>
-        <min_angular_acceleration>-7.725</min_angular_acceleration>
-        <max_angular_acceleration>7.725</max_angular_acceleration>
-        <!-- Maintain compatibility with debian installation -->
-        <min_velocity>-1.9</min_velocity>
-        <max_velocity>1.9</max_velocity>
-        <min_acceleration>-0.9</min_acceleration>
-        <max_acceleration>0.9</max_acceleration>
-      </plugin>
-    </gazebo>
-  
-    <gazebo>
       <plugin filename="libignition-gazebo-contact-system.so" name="ignition::gazebo::systems::Contact"></plugin>
     </gazebo>
-      
+
     <gazebo>
       <plugin filename="libignition-gazebo-sensors-system.so" name="ignition::gazebo::systems::Sensors">
         <render_engine>ogre</render_engine>

--- a/irobot_create_common/irobot_create_description/urdf/wheel.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/wheel.urdf.xacro
@@ -57,5 +57,18 @@
     </ros2_control>
   </xacro:if>
 
+  <xacro:if value="${gazebo == 'ignition'}">
+    <ros2_control name="${wheel_link_name}_controller" type="system">
+      <hardware>
+        <plugin>ign_ros2_control/IgnitionSystem</plugin>
+      </hardware>
+      <joint name="${wheel_joint_name}">
+        <state_interface name="velocity" />
+        <state_interface name="position" />
+        <command_interface name="velocity" />
+      </joint>
+    </ros2_control>
+  </xacro:if>
+
 </xacro:macro>
 </robot>

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ros_ignition_bridge.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ros_ignition_bridge.launch.py
@@ -68,24 +68,6 @@ def generate_launch_description():
                                'diffdrive_controller/cmd_vel_unstamped')
                           ])
 
-    # odometry bridge
-    odometry_bridge = Node(package='ros_ign_bridge', executable='parameter_bridge',
-                           namespace=namespace,
-                           name='odometry_bridge',
-                           output='screen',
-                           parameters=[{
-                               'use_sim_time': use_sim_time
-                           }],
-                           arguments=[
-                               ['/model/', LaunchConfiguration('robot_name'), '/odometry' +
-                                '@nav_msgs/msg/Odometry' +
-                                '[ignition.msgs.Odometry']
-                           ],
-                           remappings=[
-                               (['/model/', LaunchConfiguration('robot_name'), '/odometry'],
-                                '/odom')
-                           ])
-
     # odom to base_link transform bridge
     odom_base_tf_bridge = Node(package='ros_ign_bridge', executable='parameter_bridge',
                                namespace=namespace,
@@ -181,38 +163,13 @@ def generate_launch_description():
                                    '[ignition.msgs.Int32']
                               ])
 
-    # Pose bridge
-    pose_bridge = Node(package='ros_ign_bridge', executable='parameter_bridge',
-                       namespace=namespace,
-                       name='pose_bridge',
-                       output='screen',
-                       parameters=[{
-                            'use_sim_time': use_sim_time
-                       }],
-                       arguments=[
-                           ['/model/', LaunchConfiguration('robot_name'), '/pose' +
-                            '@tf2_msgs/msg/TFMessage' +
-                            '[ignition.msgs.Pose_V'],
-                           '/model/standard_dock/pose' +
-                           '@tf2_msgs/msg/TFMessage' +
-                           '[ignition.msgs.Pose_V'
-                       ],
-                       remappings=[
-                           (['/model/', LaunchConfiguration('robot_name'), '/pose'],
-                            '/_internal/sim_ground_truth_pose'),
-                           ('/model/standard_dock/pose',
-                            '/_internal/sim_ground_truth_dock_pose')
-                       ])
-
     # Create launch description and add actions
     ld = LaunchDescription(ARGUMENTS)
     ld.add_action(clock_bridge)
-    ld.add_action(odometry_bridge)
     ld.add_action(cmd_vel_bridge)
     ld.add_action(odom_base_tf_bridge)
     ld.add_action(bumper_contact_bridge)
     ld.add_action(cliff_bridge)
     ld.add_action(ir_intensity_bridge)
     ld.add_action(buttons_msg_bridge)
-    ld.add_action(pose_bridge)
     return ld


### PR DESCRIPTION
Signed-off-by: ahcorde <ahcorde@gmail.com>

## Description

Use ign_ros2_control

This PR try to provide the same diff drive controller to Gazebo classic and Ignition simulations

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

```bash
# Run this command
ros2 launch irobot_create_ignition_bringup create3_ignition.launch.py
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
