### PR TITLE
remove ros-control packages built from sources

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -3,15 +3,3 @@ repositories:
     type: git
     url: https://github.com/iRobotEducation/irobot_create_msgs.git
     version: 1.2.2
-  ros2_controllers:
-    type: git
-    url: https://github.com/iRobotEducation/ros2_controllers.git
-    version: create3_galactic
-  ros2_control:
-    type: git
-    url: https://github.com/ros-controls/ros2_control.git
-    version: 017e3c5053ef268ad907df2fc252ebcde390b05b
-  gazebo-ros2-control:
-    type: git
-    url: https://github.com/iRobotEducation/gazebo_ros2_control.git
-    version: create3_galactic

--- a/irobot_create_common/irobot_create_control/package.xml
+++ b/irobot_create_common/irobot_create_control/package.xml
@@ -13,7 +13,7 @@
 
   <exec_depend>gazebo_ros2_control</exec_depend>
   <exec_depend>irobot_create_toolbox</exec_depend>
-  <exec_depend>joint_state_controller</exec_depend>
+  <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2_controllers</exec_depend>
 


### PR DESCRIPTION

## Description

This PR removes some dependencies that were being built from sources.
All the required changes are now merged into the galactic released versions, so build from sources it's not necessary anymore.

Fixes https://github.com/iRobotEducation/create3_sim/issues/149

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

This does not affect the Gazebo ignition version.
Tested basic actions in empty world verifying that the robot was not rocking up while moving.


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
