### PR TITLE
Reliable QoS for publishers

### DIFF
--- a/irobot_create_common/irobot_create_nodes/src/hazards_vector_publisher.cpp
+++ b/irobot_create_common/irobot_create_nodes/src/hazards_vector_publisher.cpp
@@ -27,7 +27,7 @@ HazardsVectorPublisher::HazardsVectorPublisher(const rclcpp::NodeOptions & optio
     this->declare_parameter("publish_rate", 62.0);
 
   publisher_ = create_publisher<irobot_create_msgs::msg::HazardDetectionVector>(
-    publisher_topic_, rclcpp::SensorDataQoS());
+    publisher_topic_, rclcpp::SensorDataQoS().reliable());
   RCLCPP_INFO_STREAM(get_logger(), "Advertised topic: " << publisher_topic_);
 
   timer_ = rclcpp::create_timer(

--- a/irobot_create_common/irobot_create_nodes/src/ir_intensity_vector_publisher.cpp
+++ b/irobot_create_common/irobot_create_nodes/src/ir_intensity_vector_publisher.cpp
@@ -27,7 +27,7 @@ IrIntensityVectorPublisher::IrIntensityVectorPublisher(const rclcpp::NodeOptions
     this->declare_parameter("publish_rate", 62.0);
 
   publisher_ = create_publisher<irobot_create_msgs::msg::IrIntensityVector>(
-    publisher_topic_, rclcpp::SensorDataQoS());
+    publisher_topic_, rclcpp::SensorDataQoS().reliable());
   RCLCPP_INFO_STREAM(get_logger(), "Advertised topic: " << publisher_topic_);
 
   timer_ = rclcpp::create_timer(

--- a/irobot_create_common/irobot_create_nodes/src/kidnap_estimator_publisher.cpp
+++ b/irobot_create_common/irobot_create_nodes/src/kidnap_estimator_publisher.cpp
@@ -24,7 +24,7 @@ KidnapEstimator::KidnapEstimator(const rclcpp::NodeOptions & options)
 
   // Define kidnap status publisher
   kidnap_status_publisher_ = create_publisher<irobot_create_msgs::msg::KidnapStatus>(
-    kidnap_status_publisher_topic_, rclcpp::SensorDataQoS());
+    kidnap_status_publisher_topic_, rclcpp::SensorDataQoS().reliable());
   RCLCPP_INFO_STREAM(get_logger(), "Advertised topic: " << kidnap_status_publisher_topic_);
 
   // Subscription to the hazard detection vector

--- a/irobot_create_common/irobot_create_nodes/src/motion_control/docking_behavior.cpp
+++ b/irobot_create_common/irobot_create_nodes/src/motion_control/docking_behavior.cpp
@@ -26,19 +26,19 @@ DockingBehavior::DockingBehavior(
   dock_status_sub_ = rclcpp::create_subscription<irobot_create_msgs::msg::Dock>(
     node_topics_interface,
     "dock",
-    rclcpp::SensorDataQoS(),
+    rclcpp::SensorDataQoS().reliable(),
     std::bind(&DockingBehavior::dock_status_callback, this, _1));
 
   robot_pose_sub_ = rclcpp::create_subscription<nav_msgs::msg::Odometry>(
     node_topics_interface,
     "sim_ground_truth_pose",
-    rclcpp::SensorDataQoS(),
+    rclcpp::SensorDataQoS().reliable(),
     std::bind(&DockingBehavior::robot_pose_callback, this, _1));
 
   dock_pose_sub_ = rclcpp::create_subscription<nav_msgs::msg::Odometry>(
     node_topics_interface,
     "sim_ground_truth_dock_pose",
-    rclcpp::SensorDataQoS(),
+    rclcpp::SensorDataQoS().reliable(),
     std::bind(&DockingBehavior::dock_pose_callback, this, _1));
 
   docking_action_server_ = rclcpp_action::create_server<irobot_create_msgs::action::DockServo>(

--- a/irobot_create_common/irobot_create_nodes/src/motion_control_node.cpp
+++ b/irobot_create_common/irobot_create_nodes/src/motion_control_node.cpp
@@ -127,10 +127,10 @@ MotionControlNode::MotionControlNode(const rclcpp::NodeOptions & options)
     "diffdrive_controller/cmd_vel_unstamped", rclcpp::SystemDefaultsQoS());
 
   backup_limit_hazard_pub_ = this->create_publisher<irobot_create_msgs::msg::HazardDetection>(
-    "_internal/backup_limit", rclcpp::SensorDataQoS());
+    "_internal/backup_limit", rclcpp::SensorDataQoS().reliable());
 
   wheel_status_pub_ = this->create_publisher<irobot_create_msgs::msg::WheelStatus>(
-    "wheel_status", rclcpp::SensorDataQoS());
+    "wheel_status", rclcpp::SensorDataQoS().reliable());
   // Register a callback to handle parameter changes
   params_callback_handle_ = this->add_on_set_parameters_callback(
     std::bind(&MotionControlNode::set_parameters_callback, this, _1));

--- a/irobot_create_common/irobot_create_nodes/src/robot_state.cpp
+++ b/irobot_create_common/irobot_create_nodes/src/robot_state.cpp
@@ -45,7 +45,7 @@ RobotState::RobotState(const rclcpp::NodeOptions & options)
 
   // Define battery state publisher
   battery_state_publisher_ = create_publisher<sensor_msgs::msg::BatteryState>(
-    battery_state_publisher_topic_, rclcpp::SensorDataQoS());
+    battery_state_publisher_topic_, rclcpp::SensorDataQoS().reliable());
   RCLCPP_INFO_STREAM(get_logger(), "Advertised topic: " << battery_state_publisher_topic_);
 
   // Define battery parameters
@@ -56,18 +56,18 @@ RobotState::RobotState(const rclcpp::NodeOptions & options)
 
   // Subscription to the hazard detection vector
   dock_subscription_ = create_subscription<irobot_create_msgs::msg::Dock>(
-    dock_subscription_topic_, rclcpp::SensorDataQoS(),
+    dock_subscription_topic_, rclcpp::SensorDataQoS().reliable(),
     std::bind(&RobotState::dock_callback, this, std::placeholders::_1));
   RCLCPP_INFO_STREAM(get_logger(), "Subscription to topic: " << dock_subscription_topic_);
 
   // Define stop status publisher
   stop_status_publisher_ = create_publisher<irobot_create_msgs::msg::StopStatus>(
-    stop_status_publisher_topic_, rclcpp::SensorDataQoS());
+    stop_status_publisher_topic_, rclcpp::SensorDataQoS().reliable());
   RCLCPP_INFO_STREAM(get_logger(), "Advertised topic: " << stop_status_publisher_topic_);
 
   // Subscription to the stop status
   stop_status_subscription_ = create_subscription<nav_msgs::msg::Odometry>(
-    wheel_vels_subscription_topic_, rclcpp::SensorDataQoS(),
+    wheel_vels_subscription_topic_, rclcpp::SensorDataQoS().reliable(),
     std::bind(&RobotState::stop_callback, this, std::placeholders::_1));
   RCLCPP_INFO_STREAM(get_logger(), "Subscription to topic: " << wheel_vels_subscription_topic_);
 

--- a/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_bumper.cpp
+++ b/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_bumper.cpp
@@ -16,7 +16,7 @@ void GazeboRosBumper::Load(gazebo::sensors::SensorPtr sensor, sdf::ElementPtr sd
   GZ_ASSERT(bumper_, "Bumper Contact Plugin requires a Contact Sensor");
   ros_node_ = gazebo_ros::Node::Get(sdf);
   bumper_pub_ = ros_node_->create_publisher<irobot_create_msgs::msg::HazardDetection>(
-    "~/out", rclcpp::SensorDataQoS());
+    "~/out", rclcpp::SensorDataQoS().reliable());
 
   // Listen to the update event.
   update_connection_ = bumper_->ConnectUpdated(boost::bind(&GazeboRosBumper::OnUpdate, this));

--- a/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_cliff_sensor.cpp
+++ b/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_cliff_sensor.cpp
@@ -34,7 +34,7 @@ void GazeboRosCliffSensor::Load(gazebo::sensors::SensorPtr parent, sdf::ElementP
 
   // Initialize ROS publisher
   pub_ = ros_node_->create_publisher<irobot_create_msgs::msg::HazardDetection>(
-    "~/out", rclcpp::SensorDataQoS());
+    "~/out", rclcpp::SensorDataQoS().reliable());
 
   new_laser_scans_connection_ = cliff_sensor_->LaserShape()->ConnectNewLaserScans(
     std::bind(&GazeboRosCliffSensor::OnNewLaserScans, this));

--- a/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_docking_status.cpp
+++ b/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_docking_status.cpp
@@ -43,7 +43,7 @@ void GazeboRosDockingStatus::Load(gazebo::physics::ModelPtr model, sdf::ElementP
 
   // Initialize ROS publisher
   pub_ =
-    ros_node_->create_publisher<irobot_create_msgs::msg::Dock>("~/out", rclcpp::SensorDataQoS());
+    ros_node_->create_publisher<irobot_create_msgs::msg::Dock>("~/out", rclcpp::SensorDataQoS().reliable());
 
   sub_ = ros_node_->create_subscription<irobot_create_msgs::msg::IrOpcode>(
     "/ir_opcode", rclcpp::SensorDataQoS(),

--- a/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_docking_status.cpp
+++ b/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_docking_status.cpp
@@ -42,8 +42,8 @@ void GazeboRosDockingStatus::Load(gazebo::physics::ModelPtr model, sdf::ElementP
     dock_model_name, emitter_link_name);
 
   // Initialize ROS publisher
-  pub_ =
-    ros_node_->create_publisher<irobot_create_msgs::msg::Dock>("~/out", rclcpp::SensorDataQoS().reliable());
+  pub_ = ros_node_->create_publisher<irobot_create_msgs::msg::Dock>(
+    "~/out", rclcpp::SensorDataQoS().reliable());
 
   sub_ = ros_node_->create_subscription<irobot_create_msgs::msg::IrOpcode>(
     "/ir_opcode", rclcpp::SensorDataQoS(),

--- a/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_imu.cpp
+++ b/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_imu.cpp
@@ -22,7 +22,7 @@ void GazeboRosImu::Load(gazebo::sensors::SensorPtr sensor, sdf::ElementPtr sdf)
 
   gravity_ = gazebo::physics::get_world(sensor_->WorldName())->Gravity();
 
-  pub_ = ros_node_->create_publisher<sensor_msgs::msg::Imu>("~/out", rclcpp::SensorDataQoS());
+  pub_ = ros_node_->create_publisher<sensor_msgs::msg::Imu>("~/out", rclcpp::SensorDataQoS().reliable());
 
   // Get frame for message
   msg_ = std::make_shared<sensor_msgs::msg::Imu>();

--- a/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_imu.cpp
+++ b/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_imu.cpp
@@ -22,7 +22,8 @@ void GazeboRosImu::Load(gazebo::sensors::SensorPtr sensor, sdf::ElementPtr sdf)
 
   gravity_ = gazebo::physics::get_world(sensor_->WorldName())->Gravity();
 
-  pub_ = ros_node_->create_publisher<sensor_msgs::msg::Imu>("~/out", rclcpp::SensorDataQoS().reliable());
+  pub_ = ros_node_->create_publisher<sensor_msgs::msg::Imu>(
+    "~/out", rclcpp::SensorDataQoS().reliable());
 
   // Get frame for message
   msg_ = std::make_shared<sensor_msgs::msg::Imu>();

--- a/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_ir_intensity_sensor.cpp
+++ b/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_ir_intensity_sensor.cpp
@@ -29,7 +29,7 @@ void GazeboRosIrIntensitySensor::Load(gazebo::sensors::SensorPtr sensor, sdf::El
 
   // Initialize ROS publishers
   pub_ = ros_node_->create_publisher<irobot_create_msgs::msg::IrIntensity>(
-    "~/out", rclcpp::SensorDataQoS());
+    "~/out", rclcpp::SensorDataQoS().reliable());
 
   // Configure our static message charasteristics
   msg_.header.frame_id = gazebo_ros::SensorFrameID(*sensor, *sdf);

--- a/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_ir_opcode.cpp
+++ b/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_ir_opcode.cpp
@@ -56,7 +56,7 @@ void GazeboRosIrOpcode::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr sd
 
   // Initialize ROS publisher
   pub_ = ros_node_->create_publisher<irobot_create_msgs::msg::IrOpcode>(
-    "~/out", rclcpp::SensorDataQoS());
+    "~/out", rclcpp::SensorDataQoS().reliable());
 
   // Set message frame_id
   msg_.header.frame_id = receiver_link_name;

--- a/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_optical_mouse.cpp
+++ b/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_optical_mouse.cpp
@@ -34,7 +34,7 @@ void GazeboRosOpticalMouse::Load(gazebo::physics::ModelPtr model, sdf::ElementPt
   ros_node_ = gazebo_ros::Node::Get(sdf);
   // Initialize ROS publisher
   pub_ =
-    ros_node_->create_publisher<irobot_create_msgs::msg::Mouse>("~/out", rclcpp::SensorDataQoS());
+    ros_node_->create_publisher<irobot_create_msgs::msg::Mouse>("~/out", rclcpp::SensorDataQoS().reliable());
 
   // Create a connection so the OnUpdate function is called at every simulation
   // iteration. Remove this call, the connection and the callback if not needed.

--- a/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_optical_mouse.cpp
+++ b/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_optical_mouse.cpp
@@ -33,8 +33,8 @@ void GazeboRosOpticalMouse::Load(gazebo::physics::ModelPtr model, sdf::ElementPt
   // can be handled.
   ros_node_ = gazebo_ros::Node::Get(sdf);
   // Initialize ROS publisher
-  pub_ =
-    ros_node_->create_publisher<irobot_create_msgs::msg::Mouse>("~/out", rclcpp::SensorDataQoS().reliable());
+  pub_ = ros_node_->create_publisher<irobot_create_msgs::msg::Mouse>(
+    "~/out", rclcpp::SensorDataQoS().reliable());
 
   // Create a connection so the OnUpdate function is called at every simulation
   // iteration. Remove this call, the connection and the callback if not needed.

--- a/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_wheel_drop.cpp
+++ b/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_wheel_drop.cpp
@@ -35,7 +35,7 @@ void GazeboRosWheelDrop::Load(gazebo::physics::ModelPtr model, sdf::ElementPtr s
   const gazebo_ros::QoS & qos = ros_node_->get_qos();
   // Initialize ROS publisher
   pub_ = ros_node_->create_publisher<irobot_create_msgs::msg::HazardDetection>(
-    "~/out", qos.get_publisher_qos("~/out", rclcpp::SensorDataQoS()));
+    "~/out", qos.get_publisher_qos("~/out", rclcpp::SensorDataQoS().reliable()));
 
   // Create a connection so the OnUpdate function is called at every simulation
   // iteration. Remove this call, the connection and the callback if not needed.


### PR DESCRIPTION
## Description

This PR is to ensure compatibility with some subscribers making reliable as QoS's default for publishers. 

Fixes issue #135  
More information [here](https://github.com/ros-simulation/gazebo_ros_pkgs/pull/1224).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Before apply any changes I run `gazebo create3 simulation` 
```
ros2 launch irobot_create_gazebo_bringup create3_gazebo.launch.py
```
And then I verify the `QoS profile` of certains topics with 
```
ros2 topic info <topic> -v
```
So, before applying any changes the `Reliability` field inside `QoS profile` is `BEST_EFFORT`.
After applying the changes the same field change to `RELIABLE`

Also I run the example described [here](https://github.com/iRobotEducation/create3_examples/tree/galactic/create3_examples_py) before and after making changes and everything works as expected.


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
