### PR TITLE
fix CI by exporting ignition env variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ jobs:
     name: build_and_test
     runs-on: ubuntu-20.04
     steps:
+      - name: Set Ignition Version
+        run: |
+          echo "IGNITION_VERSION=edifice" >> $GITHUB_ENV
       - uses: actions/checkout@v2.3.4
       - uses: ros-tooling/setup-ros@0.2.1
         with:

--- a/dependencies.repos
+++ b/dependencies.repos
@@ -6,4 +6,4 @@ repositories:
   ignition-ros2-control:
     type: git
     url: https://github.com/ignitionrobotics/ign_ros2_control.git
-    version: galactic
+    version: 0.3.0


### PR DESCRIPTION
Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>

## Description

Fixes CI currently broken after the update of `ign_ros2_control`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

No tests, waiting for CI to run.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
