### PR TITLE
Use package:// to reference meshes

### DIFF
--- a/irobot_create_common/irobot_create_description/urdf/create3.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/create3.urdf.xacro
@@ -60,7 +60,7 @@
     <visual>
       <origin xyz="0 0 ${body_z_offset + base_link_z_offset}" rpy="0 0 ${pi/2}"/>
       <geometry>
-        <mesh filename="file://$(find irobot_create_description)/meshes/body_visual.dae" />
+        <mesh filename="package://irobot_create_description/meshes/body_visual.dae" />
       </geometry>
     </visual>
     <collision name="create3_base_collision">
@@ -83,8 +83,8 @@
   <!-- Bumper -->
   <xacro:bumper
       gazebo="$(arg gazebo)"
-      visual_mesh="file://$(find irobot_create_description)/meshes/bumper_visual.dae"
-      collision_mesh="file://$(find irobot_create_description)/meshes/bumper_collision.dae">
+      visual_mesh="package://irobot_create_description/meshes/bumper_visual.dae"
+      collision_mesh="package://irobot_create_description/meshes/bumper_collision.dae">
     <origin xyz="0 0 ${bumper_offset_z  + base_link_z_offset}"/>
     <inertial>
       <origin xyz="${bumper_inertial_x} 0 ${bumper_inertial_z}"/>

--- a/irobot_create_common/irobot_create_description/urdf/dock/standard_dock.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/dock/standard_dock.urdf.xacro
@@ -15,7 +15,7 @@
     <visual>
       <origin xyz="0 0 ${z_offset}"/>
       <geometry>
-        <mesh filename="file://$(find irobot_create_description)/meshes/dock/visual.dae"/>
+        <mesh filename="package://irobot_create_description/meshes/dock/visual.dae"/>
       </geometry>
     </visual>
     <collision>

--- a/irobot_create_gazebo/irobot_create_gazebo_bringup/launch/create3_gazebo.launch.py
+++ b/irobot_create_gazebo/irobot_create_gazebo_bringup/launch/create3_gazebo.launch.py
@@ -6,9 +6,12 @@
 
 import os
 
+from pathlib import Path
+
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchContext, LaunchDescription, SomeSubstitutionsType, Substitution
-from launch.actions import DeclareLaunchArgument, ExecuteProcess, IncludeLaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess
+from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
@@ -59,6 +62,16 @@ def generate_launch_description():
     # Directories
     pkg_create3_common_bringup = get_package_share_directory('irobot_create_common_bringup')
     pkg_create3_gazebo_bringup = get_package_share_directory('irobot_create_gazebo_bringup')
+    pkg_irobot_create_description = get_package_share_directory('irobot_create_description')
+
+    # Set ignition resource path
+    gz_resource_path = SetEnvironmentVariable(name='GAZEBO_MODEL_PATH', value=[
+                                                '/usr/share/gazebo-11/models/:',
+                                                str(Path(pkg_irobot_create_description).
+                                                    parent.resolve())])
+
+    # Set GAZEBO_MODEL_URI to empty string to prevent Gazebo from downloading models
+    gz_model_uri = SetEnvironmentVariable(name='GAZEBO_MODEL_URI', value=[''])
 
     # Paths
     create3_nodes_launch_file = PathJoinSubstitution(
@@ -158,6 +171,8 @@ def generate_launch_description():
     # Define LaunchDescription variable
     ld = LaunchDescription(ARGUMENTS)
     # Gazebo processes
+    ld.add_action(gz_resource_path)
+    ld.add_action(gz_model_uri)
     ld.add_action(gzserver)
     ld.add_action(gzclient)
     # Include robot description

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition.launch.py
@@ -3,6 +3,8 @@
 
 import os
 
+from pathlib import Path
+
 from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchContext, LaunchDescription, SomeSubstitutionsType, Substitution
@@ -57,35 +59,46 @@ for pose_element in ['x', 'y', 'z', 'yaw']:
 def generate_launch_description():
 
     # Directories
-    pkg_create3_common_bringup = get_package_share_directory('irobot_create_common_bringup')
-    pkg_create3_ignition_bringup = get_package_share_directory('irobot_create_ignition_bringup')
-    pkg_create3_ignition_plugins = get_package_share_directory('irobot_create_ignition_plugins')
-    pkg_ros_ign_gazebo = get_package_share_directory('ros_ign_gazebo')
+    pkg_irobot_create_common_bringup = get_package_share_directory(
+        'irobot_create_common_bringup')
+    pkg_irobot_create_ignition_bringup = get_package_share_directory(
+        'irobot_create_ignition_bringup')
+    pkg_irobot_create_ignition_plugins = get_package_share_directory(
+        'irobot_create_ignition_plugins')
+    pkg_irobot_create_description = get_package_share_directory(
+        'irobot_create_description')
+    pkg_ros_ign_gazebo = get_package_share_directory(
+        'ros_ign_gazebo')
 
     # Set Ignition resource path
     ign_resource_path = SetEnvironmentVariable(name='IGN_GAZEBO_RESOURCE_PATH',
-                                               value=[os.path.join(pkg_create3_ignition_bringup,
-                                                      'worlds')])
+                                               value=[os.path.join(
+                                                      pkg_irobot_create_ignition_bringup,
+                                                      'worlds'), ':' +
+                                                      str(Path(
+                                                          pkg_irobot_create_description).
+                                                          parent.resolve())])
 
     ign_gui_plugin_path = SetEnvironmentVariable(name='IGN_GUI_PLUGIN_PATH',
-                                                 value=[os.path.join(pkg_create3_ignition_plugins,
+                                                 value=[os.path.join(
+                                                        pkg_irobot_create_ignition_plugins,
                                                         'lib')])
 
     # Paths
     ign_gazebo_launch = PathJoinSubstitution(
         [pkg_ros_ign_gazebo, 'launch', 'ign_gazebo.launch.py'])
     ros_ign_bridge_launch = PathJoinSubstitution(
-        [pkg_create3_ignition_bringup, 'launch', 'create3_ros_ignition_bridge.launch.py'])
+        [pkg_irobot_create_ignition_bringup, 'launch', 'create3_ros_ignition_bridge.launch.py'])
     create3_nodes_launch = PathJoinSubstitution(
-        [pkg_create3_common_bringup, 'launch', 'create3_nodes.launch.py'])
+        [pkg_irobot_create_common_bringup, 'launch', 'create3_nodes.launch.py'])
     create3_ignition_nodes_launch = PathJoinSubstitution(
-        [pkg_create3_ignition_bringup, 'launch', 'create3_ignition_nodes.launch.py'])
+        [pkg_irobot_create_ignition_bringup, 'launch', 'create3_ignition_nodes.launch.py'])
     robot_description_launch = PathJoinSubstitution(
-        [pkg_create3_common_bringup, 'launch', 'robot_description.launch.py'])
+        [pkg_irobot_create_common_bringup, 'launch', 'robot_description.launch.py'])
     dock_description_launch = PathJoinSubstitution(
-        [pkg_create3_common_bringup, 'launch', 'dock_description.launch.py'])
+        [pkg_irobot_create_common_bringup, 'launch', 'dock_description.launch.py'])
     rviz2_launch = PathJoinSubstitution(
-        [pkg_create3_common_bringup, 'launch', 'rviz2.launch.py'])
+        [pkg_irobot_create_common_bringup, 'launch', 'rviz2.launch.py'])
 
     # Launch configurations
     x, y, z = LaunchConfiguration('x'), LaunchConfiguration('y'), LaunchConfiguration('z')
@@ -99,7 +112,7 @@ def generate_launch_description():
                           '.sdf',
                           ' -v 4',
                           ' --gui-config ',
-                          PathJoinSubstitution([pkg_create3_ignition_bringup,
+                          PathJoinSubstitution([pkg_irobot_create_ignition_bringup,
                                                 'gui', 'create3', 'gui.config'])])
         ]
     )


### PR DESCRIPTION
## Description

Switching to package:// allows the description to be used by a remote computer as the mesh paths become relative rather than absolute.

Changes:
- Set GAZEBO_MODEL_URI to empty string to prevent model downloads.
- Added /usr/share/gazebo-11/models/ to GAZEBO_MODEL_PATH to use local ground plane and sun models.
- Using package:// instead of file:// for mesh paths.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

```bash
# Run this command
ros2 launch package launch.py
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
