### PR TITLE
remove ignition-ros2-control from dependencies.repos

### DIFF
--- a/dependencies.repos
+++ b/dependencies.repos
@@ -3,7 +3,3 @@ repositories:
     type: git
     url: https://github.com/iRobotEducation/irobot_create_msgs.git
     version: 1.2.4
-  ignition-ros2-control:
-    type: git
-    url: https://github.com/ignitionrobotics/ign_ros2_control.git
-    version: 0.3.0


### PR DESCRIPTION
remove ignition-ros2-control from dependencies.repos this is now available via rosdep

Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>

## Description

This PR re-introduces the changes proposed in https://github.com/iRobotEducation/create3_sim/pull/169 now that `ignition-ros2-control` has been officially released.

Fixes # (issue).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Check that `rosdep install --from-path src -yi` now installs `ros-galactic-ign-ros2-control (0.4.0-1focal.20220319.052953)`


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
