### PR TITLE
fix setting environment variable GAZEBO_MODEL_PATH for aws models

### DIFF
--- a/irobot_create_gazebo/irobot_create_gazebo_bringup/launch/create3_gazebo_aws_small.launch.py
+++ b/irobot_create_gazebo/irobot_create_gazebo_bringup/launch/create3_gazebo_aws_small.launch.py
@@ -26,7 +26,7 @@ def generate_launch_description():
     create3_launch_file = PathJoinSubstitution(
         [irobot_create_gazebo_bringup_dir, 'launch', 'create3_gazebo.launch.py'])
     world_path = PathJoinSubstitution([aws_small_house_dir, 'worlds', 'small_house.world'])
-    aws_model_path = PathJoinSubstitution([aws_small_house_dir, 'models'])
+    aws_model_path = PathJoinSubstitution([aws_small_house_dir, 'models:'])
 
     # Includes
     world_spawn = IncludeLaunchDescription(


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Also, include relevant motivation and context.
The GAZEBO_MODEL_PATH for the aws-robomaker-small-house-world models folder was not being set properly since between path `:` was missing. 

Fixes # (issue).
The PR fixes the above issue
## Type of change

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Also, list any relevant details for your test configuration.

```bash
# Run this command
ros2 launch irobot_create_gazebo_bringup create3_gazebo_aws_small.launch.py
```

## Checklist

- [ *] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
