### PR TITLE
add boost as explicit dependency and remove unnneded boost usage

### DIFF
--- a/irobot_create_common/irobot_create_nodes/CMakeLists.txt
+++ b/irobot_create_common/irobot_create_nodes/CMakeLists.txt
@@ -25,7 +25,7 @@ find_package(rclcpp_components REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
-find_package(Boost COMPONENTS boost REQUIRED)
+find_package(Boost REQUIRED)
 
 #### Libraries
 

--- a/irobot_create_common/irobot_create_nodes/CMakeLists.txt
+++ b/irobot_create_common/irobot_create_nodes/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(rclcpp_components REQUIRED)
 find_package(tf2 REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
 find_package(tf2_ros REQUIRED)
+find_package(Boost COMPONENTS boost REQUIRED)
 
 #### Libraries
 
@@ -42,6 +43,7 @@ set(dependencies
   tf2
   tf2_geometry_msgs
   tf2_ros
+  Boost
 )
 
 # Hazards vector publisher

--- a/irobot_create_common/irobot_create_nodes/package.xml
+++ b/irobot_create_common/irobot_create_nodes/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <depend>angles</depend>
+  <depend>boost</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>
   <depend>rclcpp_components</depend>

--- a/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_bumper.cpp
+++ b/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_bumper.cpp
@@ -19,7 +19,7 @@ void GazeboRosBumper::Load(gazebo::sensors::SensorPtr sensor, sdf::ElementPtr sd
     "~/out", rclcpp::SensorDataQoS().reliable());
 
   // Listen to the update event.
-  update_connection_ = bumper_->ConnectUpdated(boost::bind(&GazeboRosBumper::OnUpdate, this));
+  update_connection_ = bumper_->ConnectUpdated(std::bind(&GazeboRosBumper::OnUpdate, this));
 
   // Initialize gazebo node and subscribe to pose topic
   gz_node_.reset(new gazebo::transport::Node());


### PR DESCRIPTION
Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>

## Description

This PR fixes a bug related to the boost library.
`boost::optional` is used by the `irobot_create_nodes` library so it need to be explicitly listed as a dependency.

`boost` was also used in `gazebo_ros_bumper.cpp`, but here I think it's better to just use the std library.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

None

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
