### PR TITLE
Draft: adding namespaces to create3

### DIFF
--- a/irobot_create_common/irobot_create_common_bringup/CMakeLists.txt
+++ b/irobot_create_common/irobot_create_common_bringup/CMakeLists.txt
@@ -11,6 +11,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
 
 install(
   DIRECTORY
@@ -20,6 +21,9 @@ install(
   DESTINATION
     share/${PROJECT_NAME}
 )
+
+# Install Python modules
+ament_python_install_package(${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/irobot_create_common/irobot_create_common_bringup/config/hazard_vector_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/hazard_vector_params.yaml
@@ -1,5 +1,5 @@
 ---
-hazards_vector_publisher:
+/**:
   ros__parameters:
     # Hazard detection publisher topic
     publisher_topic: /hazard_detection

--- a/irobot_create_common/irobot_create_common_bringup/config/ir_intensity_vector_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/ir_intensity_vector_params.yaml
@@ -1,5 +1,5 @@
 ---
-ir_intensity_vector_publisher:
+/**:
   ros__parameters:
     # IR intensity publisher topic
     publisher_topic: /ir_intensity

--- a/irobot_create_common/irobot_create_common_bringup/config/kidnap_estimator_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/kidnap_estimator_params.yaml
@@ -1,5 +1,5 @@
 ---
-kidnap_estimator_publisher:
+/**:
   ros__parameters:
     # Kidnap status publisher topic
     kidnap_status_topic: /kidnap_status

--- a/irobot_create_common/irobot_create_common_bringup/config/mock_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/mock_params.yaml
@@ -1,5 +1,5 @@
 ---
-mock_publisher:
+/**:
   ros__parameters:
     # Mock slip status publisher topic
     slip_status_topic: /slip_status

--- a/irobot_create_common/irobot_create_common_bringup/config/robot_state_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/robot_state_params.yaml
@@ -1,5 +1,5 @@
 ---
-robot_state:
+/**:
   ros__parameters:
     # Stop status publisher topic
     stop_status_topic: /stop_status

--- a/irobot_create_common/irobot_create_common_bringup/config/ui_mgr_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/ui_mgr_params.yaml
@@ -1,5 +1,5 @@
 ---
-ui_mgr:
+/**:
   ros__parameters:
     # Buttons publisher topic
     button_topic: /interface_buttons

--- a/irobot_create_common/irobot_create_common_bringup/config/wheel_status_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/wheel_status_params.yaml
@@ -1,5 +1,5 @@
 ---
-wheel_status_publisher:
+/**:
   ros__parameters:
     # Publish rate
     publish_rate: 62.0

--- a/irobot_create_common/irobot_create_common_bringup/irobot_create_common_bringup/offset_parser.py
+++ b/irobot_create_common/irobot_create_common_bringup/irobot_create_common_bringup/offset_parser.py
@@ -1,0 +1,18 @@
+from launch import LaunchContext, SomeSubstitutionsType, Substitution
+
+
+class OffsetParser(Substitution):
+    def __init__(
+            self,
+            number: SomeSubstitutionsType,
+            offset: float,
+    ) -> None:
+        self.__number = number
+        self.__offset = offset
+
+    def perform(
+            self,
+            context: LaunchContext = None,
+    ) -> str:
+        number = float(self.__number.perform(context))
+        return f'{number + self.__offset}'

--- a/irobot_create_common/irobot_create_common_bringup/irobot_create_common_bringup/replace_string.py
+++ b/irobot_create_common/irobot_create_common_bringup/irobot_create_common_bringup/replace_string.py
@@ -1,0 +1,83 @@
+# This file has been copied from https://github.com/ros-planning/navigation2
+# for use as part of the iRobot Create 3 simulator.
+#
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tempfile
+from typing import Dict
+from typing import List
+from typing import Text
+
+import launch
+
+
+class ReplaceString(launch.Substitution):
+    """
+    Substitution that replaces strings on a given file.
+
+    Used in launch system
+    """
+
+    def __init__(self,
+                 source_file: launch.SomeSubstitutionsType,
+                 replacements: Dict) -> None:
+        super().__init__()
+
+        # import here to avoid loop
+        from launch.utilities import normalize_to_list_of_substitutions
+        self.__source_file = normalize_to_list_of_substitutions(source_file)
+        self.__replacements = {}
+        for key in replacements:
+            self.__replacements[key] = normalize_to_list_of_substitutions(replacements[key])
+
+    @property
+    def name(self) -> List[launch.Substitution]:
+        """Getter for name."""
+        return self.__source_file
+
+    def describe(self) -> Text:
+        """Return a description of this substitution as a string."""
+        return ''
+
+    def perform(self, context: launch.LaunchContext) -> Text:
+        output_file = tempfile.NamedTemporaryFile(mode='w', delete=False)
+        replacements = self.resolve_replacements(context)
+        try:
+            input_file = open(launch.utilities.perform_substitutions(context, self.name), 'r')
+            self.replace(input_file, output_file, replacements)
+        except Exception as err:  # noqa: B902
+            print('ReplaceString substitution error: ', err)
+        finally:
+            input_file.close()
+            output_file.close()
+        return output_file.name
+
+    def resolve_replacements(self, context):
+        resolved_replacements = {}
+        for key in self.__replacements:
+            resolved_replacements[key] = (launch.utilities.perform_substitutions
+                                          (context, self.__replacements[key]))
+        return resolved_replacements
+
+    def replace(self, input_file, output_file, replacements):
+        for line in input_file:
+            for key, value in replacements.items():
+                if isinstance(key, str) and isinstance(value, str):
+                    if key in line:
+                        line = line.replace(key, value)
+                else:
+                    raise TypeError('A provided replacement pair is not a string.\
+                                        Both key and value should be strings.')
+                output_file.write(line)

--- a/irobot_create_common/irobot_create_common_bringup/launch/create3_nodes.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/create3_nodes.launch.py
@@ -5,12 +5,13 @@
 # Launch Create(R) 3 nodes
 
 from ament_index_python.packages import get_package_share_directory
+from irobot_create_common_bringup.replace_string import ReplaceString
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.conditions import LaunchConfigurationEquals, LaunchConfigurationNotEquals
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
-from nav2_common.launch import ReplaceString
 
 ARGUMENTS = [
     DeclareLaunchArgument('gazebo', default_value='classic',
@@ -26,6 +27,7 @@ def generate_launch_description():
     # Directories
     pkg_create3_common_bringup = get_package_share_directory('irobot_create_common_bringup')
     pkg_create3_control = get_package_share_directory('irobot_create_control')
+    namespace = LaunchConfiguration('namespace')
 
     # Paths
     control_launch_file = PathJoinSubstitution(
@@ -51,8 +53,6 @@ def generate_launch_description():
         launch_arguments=[('namespace', LaunchConfiguration('namespace'))]
     )
 
-    namespace = LaunchConfiguration('namespace')
-
     namespaced_hazards_params_yaml_file = ReplaceString(
         source_file=hazards_params_yaml_file,
         replacements={'/hazard_detection': ('/', namespace, '/hazard_detection')}
@@ -66,7 +66,7 @@ def generate_launch_description():
     namespaced_wheel_status_params_yaml_file = ReplaceString(
         source_file=wheel_status_params_yaml_file,
         replacements={'/wheel_vels': ('/', namespace, '/wheel_vels'),
-        '/wheel_ticks': ('/', namespace, '/wheel_ticks')}
+                      '/wheel_ticks': ('/', namespace, '/wheel_ticks')}
     )
 
     namespaced_mock_params_yaml_file = ReplaceString(
@@ -77,26 +77,38 @@ def generate_launch_description():
     namespaced_robot_state_yaml_file = ReplaceString(
         source_file=robot_state_yaml_file,
         replacements={'/stop_status': ('/', namespace, '/stop_status'),
-        '/battery_state': ('/', namespace, '/battery_state'),
-        '/dock': ('/', namespace, '/dock'),
-        '/odom': ('/', namespace, '/odom')}
+                      '/battery_state': ('/', namespace, '/battery_state'),
+                      '/dock': ('/', namespace, '/dock'),
+                      '/odom': ('/', namespace, '/odom')}
     )
 
     namespaced_kidnap_estimator_yaml_file = ReplaceString(
         source_file=kidnap_estimator_yaml_file,
         replacements={'/kidnap_status': ('/', namespace, '/kidnap_status'),
-        '/hazard_detection': ('/', namespace, '/hazard_detection')}
+                      '/hazard_detection': ('/', namespace, '/hazard_detection')}
     )
 
     namespaced_ui_mgr_params_yaml_file = ReplaceString(
         source_file=ui_mgr_params_yaml_file,
         replacements={'/interface_buttons': ('/', namespace, '/interface_buttons'),
-        '/cmd_lightring': ('/', namespace, '/cmd_lightring'),
-        '/cmd_audio': ('/', namespace, '/cmd_audio')}
+                      '/cmd_lightring': ('/', namespace, '/cmd_lightring'),
+                      '/cmd_audio': ('/', namespace, '/cmd_audio')}
     )
 
     # Publish hazards vector
     hazards_vector_node = Node(
+        condition=LaunchConfigurationEquals('namespace', ''),
+        package='irobot_create_nodes',
+        name='hazards_vector_publisher',
+        namespace=namespace,
+        executable='hazards_vector_publisher',
+        parameters=[hazards_params_yaml_file,
+                    {'use_sim_time': True}],
+        output='screen',
+    )
+
+    hazards_vector_node_namespaced = Node(
+        condition=LaunchConfigurationNotEquals('namespace', ''),
         package='irobot_create_nodes',
         name='hazards_vector_publisher',
         namespace=namespace,
@@ -108,6 +120,18 @@ def generate_launch_description():
 
     # Publish IR intensity vector
     ir_intensity_vector_node = Node(
+        condition=LaunchConfigurationEquals('namespace', ''),
+        package='irobot_create_nodes',
+        name='ir_intensity_vector_publisher',
+        namespace=namespace,
+        executable='ir_intensity_vector_publisher',
+        parameters=[ir_intensity_params_yaml_file,
+                    {'use_sim_time': True}],
+        output='screen',
+    )
+
+    ir_intensity_vector_node_namespaced = Node(
+        condition=LaunchConfigurationNotEquals('namespace', ''),
         package='irobot_create_nodes',
         name='ir_intensity_vector_publisher',
         namespace=namespace,
@@ -129,6 +153,18 @@ def generate_launch_description():
 
     # Publish wheel status
     wheel_status_node = Node(
+        condition=LaunchConfigurationEquals('namespace', ''),
+        package='irobot_create_nodes',
+        name='wheel_status_publisher',
+        namespace=namespace,
+        executable='wheel_status_publisher',
+        parameters=[wheel_status_params_yaml_file,
+                    {'use_sim_time': True}],
+        output='screen',
+    )
+
+    wheel_status_node_namespaced = Node(
+        condition=LaunchConfigurationNotEquals('namespace', ''),
         package='irobot_create_nodes',
         name='wheel_status_publisher',
         namespace=namespace,
@@ -140,6 +176,18 @@ def generate_launch_description():
 
     # Publish mock topics
     mock_topics_node = Node(
+        condition=LaunchConfigurationEquals('namespace', ''),
+        package='irobot_create_nodes',
+        name='mock_publisher',
+        namespace=namespace,
+        executable='mock_publisher',
+        parameters=[mock_params_yaml_file,
+                    {'use_sim_time': True}],
+        output='screen',
+    )
+
+    mock_topics_node_namespaced = Node(
+        condition=LaunchConfigurationNotEquals('namespace', ''),
         package='irobot_create_nodes',
         name='mock_publisher',
         namespace=namespace,
@@ -151,6 +199,18 @@ def generate_launch_description():
 
     # Publish robot state
     robot_state_node = Node(
+        condition=LaunchConfigurationEquals('namespace', ''),
+        package='irobot_create_nodes',
+        name='robot_state',
+        namespace=namespace,
+        executable='robot_state',
+        parameters=[robot_state_yaml_file,
+                    {'use_sim_time': True}],
+        output='screen',
+    )
+
+    robot_state_node_namespaced = Node(
+        condition=LaunchConfigurationNotEquals('namespace', ''),
         package='irobot_create_nodes',
         name='robot_state',
         namespace=namespace,
@@ -162,6 +222,18 @@ def generate_launch_description():
 
     # Publish kidnap estimator
     kidnap_estimator_node = Node(
+        condition=LaunchConfigurationEquals('namespace', ''),
+        package='irobot_create_nodes',
+        name='kidnap_estimator_publisher',
+        namespace=namespace,
+        executable='kidnap_estimator_publisher',
+        parameters=[kidnap_estimator_yaml_file,
+                    {'use_sim_time': True}],
+        output='screen',
+    )
+
+    kidnap_estimator_node_namespaced = Node(
+        condition=LaunchConfigurationNotEquals('namespace', ''),
         package='irobot_create_nodes',
         name='kidnap_estimator_publisher',
         namespace=namespace,
@@ -173,6 +245,19 @@ def generate_launch_description():
 
     # UI topics / actions
     ui_mgr_node = Node(
+        condition=LaunchConfigurationEquals('namespace', ''),
+        package='irobot_create_nodes',
+        name='ui_mgr',
+        namespace=namespace,
+        executable='ui_mgr',
+        parameters=[ui_mgr_params_yaml_file,
+                    {'use_sim_time': True},
+                    {'gazebo': LaunchConfiguration('gazebo')}],
+        output='screen',
+    )
+
+    ui_mgr_node_namespaced = Node(
+        condition=LaunchConfigurationNotEquals('namespace', ''),
         package='irobot_create_nodes',
         name='ui_mgr',
         namespace=namespace,
@@ -189,12 +274,19 @@ def generate_launch_description():
     ld.add_action(diffdrive_controller)
     # Add nodes to LaunchDescription
     ld.add_action(hazards_vector_node)
+    ld.add_action(hazards_vector_node_namespaced)
     ld.add_action(ir_intensity_vector_node)
+    ld.add_action(ir_intensity_vector_node_namespaced)
     ld.add_action(motion_control_node)
     ld.add_action(wheel_status_node)
+    ld.add_action(wheel_status_node_namespaced)
     ld.add_action(mock_topics_node)
+    ld.add_action(mock_topics_node_namespaced)
     ld.add_action(robot_state_node)
+    ld.add_action(robot_state_node_namespaced)
     ld.add_action(kidnap_estimator_node)
+    ld.add_action(kidnap_estimator_node_namespaced)
     ld.add_action(ui_mgr_node)
+    ld.add_action(ui_mgr_node_namespaced)
 
     return ld

--- a/irobot_create_common/irobot_create_common_bringup/launch/dock_description.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/dock_description.launch.py
@@ -13,11 +13,13 @@ from launch_ros.actions import Node
 ARGUMENTS = [
     DeclareLaunchArgument('gazebo', default_value='classic',
                           choices=['classic', 'ignition'],
-                          description='Which gazebo simulation to use')
+                          description='Which gazebo simulation to use'),
+    DeclareLaunchArgument('namespace', default_value='',
+                          description='Create3 namespace')
 ]
 for pose_element in ['x', 'y', 'z', 'yaw']:
     ARGUMENTS.append(DeclareLaunchArgument(f'{pose_element}', default_value='0.0',
-                     description=f'{pose_element} component of the dock pose.'))
+                                           description=f'{pose_element} component of the dock pose.'))
 
 ARGUMENTS.append(DeclareLaunchArgument('visualize_rays', default_value='true',
                                        choices=['true', 'false'],
@@ -26,16 +28,18 @@ ARGUMENTS.append(DeclareLaunchArgument('visualize_rays', default_value='true',
 
 def generate_launch_description():
     # Directory
-    pkg_create3_description = get_package_share_directory('irobot_create_description')
+    pkg_create3_description = get_package_share_directory(
+        'irobot_create_description')
     # Path
     dock_xacro_file = PathJoinSubstitution(
         [pkg_create3_description, 'urdf', 'dock', 'standard_dock.urdf.xacro'])
 
     # Launch Configurations
-    x, y, z = LaunchConfiguration('x'), LaunchConfiguration('y'), LaunchConfiguration('z')
+    x, y, z = LaunchConfiguration('x'), LaunchConfiguration(
+        'y'), LaunchConfiguration('z')
     yaw = LaunchConfiguration('yaw')
     visualize_rays = LaunchConfiguration('visualize_rays')
-
+    namespace = LaunchConfiguration('namespace')
     gazebo_simulator = LaunchConfiguration('gazebo')
 
     state_publisher = Node(
@@ -47,12 +51,13 @@ def generate_launch_description():
             {'use_sim_time': True},
             {'robot_description':
              Command(
-                ['xacro', ' ', dock_xacro_file, ' ',
-                 'gazebo:=', gazebo_simulator, ' ',
-                 'visualize_rays:=', visualize_rays])},
+                 ['xacro', ' ', dock_xacro_file, ' ',
+                  'gazebo:=', gazebo_simulator, ' ',
+                  'visualize_rays:=', visualize_rays, ' ',
+                  'namespace:=', namespace, ' '])},
         ],
         remappings=[
-            ('robot_description', 'standard_dock_description'),
+            ('robot_description', (namespace, '/standard_dock_description')),
         ],
     )
 

--- a/irobot_create_common/irobot_create_common_bringup/launch/robot_description.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/robot_description.launch.py
@@ -16,7 +16,9 @@ ARGUMENTS = [
                           description='Which gazebo simulator to use'),
     DeclareLaunchArgument('visualize_rays', default_value='false',
                           choices=['true', 'false'],
-                          description='Enable/disable ray visualization')
+                          description='Enable/disable ray visualization'),
+    DeclareLaunchArgument('namespace', default_value='',
+                          description='Create3 namespace')
 ]
 
 
@@ -25,11 +27,13 @@ def generate_launch_description():
     xacro_file = PathJoinSubstitution([pkg_create3_description, 'urdf', 'create3.urdf.xacro'])
     gazebo_simulator = LaunchConfiguration('gazebo')
     visualize_rays = LaunchConfiguration('visualize_rays')
+    namespace = LaunchConfiguration('namespace')
 
     robot_state_publisher = Node(
         package='robot_state_publisher',
         executable='robot_state_publisher',
         name='robot_state_publisher',
+        namespace=LaunchConfiguration('namespace'),
         output='screen',
         parameters=[
             {'use_sim_time': True},
@@ -37,7 +41,8 @@ def generate_launch_description():
              Command(
                   ['xacro', ' ', xacro_file, ' ',
                    'gazebo:=', gazebo_simulator, ' ',
-                   'visualize_rays:=', visualize_rays])},
+                   'visualize_rays:=', visualize_rays, ' ',
+                   'namespace:=', namespace, ' '])},
         ],
     )
 
@@ -45,6 +50,7 @@ def generate_launch_description():
         package='joint_state_publisher',
         executable='joint_state_publisher',
         name='joint_state_publisher',
+        namespace=LaunchConfiguration('namespace'),
         output='screen',
     )
 

--- a/irobot_create_common/irobot_create_common_bringup/launch/robot_description.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/robot_description.launch.py
@@ -42,7 +42,8 @@ def generate_launch_description():
                   ['xacro', ' ', xacro_file, ' ',
                    'gazebo:=', gazebo_simulator, ' ',
                    'visualize_rays:=', visualize_rays, ' ',
-                   'namespace:=', namespace, ' '])},
+                   'namespace:=', namespace, ' '
+                   ])},
         ],
     )
 

--- a/irobot_create_common/irobot_create_common_bringup/launch/rviz2.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/rviz2.launch.py
@@ -49,7 +49,7 @@ def generate_launch_description():
         ]
     )
 
-    rviz = Node(
+    rviz_namespaced = Node(
         condition=LaunchConfigurationNotEquals('namespace', ''),
         package='rviz2',
         executable='rviz2',
@@ -71,5 +71,6 @@ def generate_launch_description():
     ld = LaunchDescription()
     # Add nodes to LaunchDescription
     ld.add_action(rviz)
+    ld.add_action(rviz_namespaced)
 
     return ld

--- a/irobot_create_common/irobot_create_common_bringup/launch/rviz2.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/rviz2.launch.py
@@ -5,24 +5,65 @@
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.substitutions import PathJoinSubstitution
+from launch.actions import DeclareLaunchArgument
+from launch.conditions import LaunchConfigurationEquals, LaunchConfigurationNotEquals
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
+from nav2_common.launch import ReplaceString
+
+ARGUMENTS = [
+    DeclareLaunchArgument('namespace', default_value='',
+                          description='robot namespace')
+]
 
 
 def generate_launch_description():
-    create_bringup = get_package_share_directory('irobot_create_common_bringup')
+    create_bringup = get_package_share_directory(
+        'irobot_create_common_bringup')
+
+    namespace = LaunchConfiguration('namespace')
 
     # Rviz
-    rviz_config = PathJoinSubstitution([create_bringup, 'rviz', 'irobot_create_view.rviz'])
-    rviz_logo = PathJoinSubstitution([create_bringup, 'rviz', 'irobot_logo.jpg'])
+    rviz_config = PathJoinSubstitution(
+        [create_bringup, 'rviz', 'irobot_create_view.rviz'])
+    rviz_logo = PathJoinSubstitution(
+        [create_bringup, 'rviz', 'irobot_logo.jpg'])
+
+    namespaced_rviz_config_file = ReplaceString(
+        source_file=rviz_config,
+        replacements={'/robot_description': ('/', namespace, '/robot_description'),
+                      '/standard_dock_description': ('/', namespace, '/standard_dock_description'),
+                      '/initialpose': ('/', namespace, '/initialpose'),
+                      '/clicked_point': ('/', namespace, '/clicked_point'),
+                      '/goal_pose': ('/', namespace, '/goal_pose')}
+    )
 
     rviz = Node(
+        condition=LaunchConfigurationEquals('namespace', ''),
         package='rviz2',
         executable='rviz2',
         name='rviz2',
         arguments=[
             '--display-config', rviz_config,
             '--splash-screen', rviz_logo,
+        ]
+    )
+
+    rviz = Node(
+        condition=LaunchConfigurationNotEquals('namespace', ''),
+        package='rviz2',
+        executable='rviz2',
+        name='rviz2',
+        arguments=[
+            '--display-config', namespaced_rviz_config_file,
+            '--splash-screen', rviz_logo,
+        ],
+        remappings=[
+            ('/tf', 'tf'),
+            ('/tf_static', 'tf_static'),
+            ('/goal_pose', 'goal_pose'),
+            ('/clicked_point', 'clicked_point'),
+            ('/initialpose', 'initialpose')
         ]
     )
 

--- a/irobot_create_common/irobot_create_common_bringup/package.xml
+++ b/irobot_create_common/irobot_create_common_bringup/package.xml
@@ -10,6 +10,7 @@
   <author>iRobot</author>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <exec_depend>irobot_create_control</exec_depend>
   <exec_depend>irobot_create_description</exec_depend>

--- a/irobot_create_common/irobot_create_control/config/control.yaml
+++ b/irobot_create_common/irobot_create_control/config/control.yaml
@@ -1,4 +1,4 @@
-controller_manager:
+/**:
   ros__parameters:
     update_rate: 1000  # Hz
 
@@ -8,7 +8,7 @@ controller_manager:
     diffdrive_controller:
       type: diff_drive_controller/DiffDriveController
 
-diffdrive_controller:
+/**:
   ros__parameters:
     use_sim_time: True
     left_wheel_names: ["left_wheel_joint"]

--- a/irobot_create_common/irobot_create_control/config/control.yaml
+++ b/irobot_create_common/irobot_create_control/config/control.yaml
@@ -6,7 +6,7 @@
       type: joint_state_broadcaster/JointStateBroadcaster
 
     diffdrive_controller:
-      type: diff_drive_controller/DiffDriveController
+      type: diff_drive_controller/DiffDriveController   
 
 /**:
   ros__parameters:

--- a/irobot_create_common/irobot_create_control/launch/include/control.py
+++ b/irobot_create_common/irobot_create_control/launch/include/control.py
@@ -15,7 +15,6 @@ ARGUMENTS = [
                           description='Robot namespace')
 ]
 
-
 def generate_launch_description():
     namespace = LaunchConfiguration('namespace')
     namespaced_node_name = [namespace, '/controller_manager']

--- a/irobot_create_common/irobot_create_description/urdf/create3.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/create3.urdf.xacro
@@ -55,6 +55,7 @@
   <xacro:property name="dock_model_name" value="standard_dock"/>
   <xacro:property name="emitter_link_name" value="halo_link"/>
   <xacro:arg name="visualize_rays" default="false"/>
+  <xacro:arg name="namespace" default=""/>
   <!-- Create 3 base definition-->
   <link name="base_link">
     <visual>
@@ -117,6 +118,9 @@
     <gazebo>
       <plugin name="gazebo_ros2_control" filename="libgazebo_ros2_control.so">
         <parameters> $(find irobot_create_control)/config/control.yaml </parameters>
+        <ros>
+          <namespace>$(arg namespace)</namespace>
+        </ros>
       </plugin>
     </gazebo>
   </xacro:if>
@@ -125,6 +129,9 @@
     <gazebo>
       <plugin filename="ign_ros2_control-system" name="ign_ros2_control::IgnitionROS2ControlPlugin">
         <parameters> $(find irobot_create_control)/config/control.yaml </parameters>
+        <ros>
+          <namespace>$(arg namespace)</namespace>
+        </ros>
       </plugin>
     </gazebo>
   </xacro:if>
@@ -235,7 +242,7 @@
     <gazebo>
       <plugin name="gazebo_ros_p3d_robot" filename="libgazebo_ros_p3d.so">
         <ros>
-          <namespace>/</namespace>
+          <namespace>$(arg namespace)</namespace>
           <remapping>odom:=sim_ground_truth_pose</remapping>
         </ros>
         <body_name>base_link</body_name>
@@ -251,7 +258,7 @@
     <gazebo>
       <plugin name="dock_status_publisher" filename="libgazebo_ros_create_docking_status.so">
         <ros>
-          <namespace>/</namespace>
+          <namespace>$(arg namespace)</namespace>
           <remapping>~/out:=dock</remapping>
         </ros>
         <update_rate>1.0</update_rate>

--- a/irobot_create_common/irobot_create_description/urdf/dock/standard_dock.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/dock/standard_dock.urdf.xacro
@@ -5,6 +5,7 @@
 
   <!-- Gazebo version -->
   <xacro:arg name="gazebo"         default="classic" />
+  <xacro:arg name="namespace" default=""/>
 
   <xacro:property name="z_offset"  value="${4.6*mm2m}"/>
   <xacro:property name="link_name" value="std_dock_link"/>
@@ -88,7 +89,7 @@
       <!-- Ground truth pose-->
       <plugin name="gazebo_ros_p3d_dock" filename="libgazebo_ros_p3d.so">
         <ros>
-          <namespace>/</namespace>
+          <namespace>$(arg namespace)</namespace>
           <remapping>odom:=sim_ground_truth_dock_pose</remapping>
         </ros>
         <body_name>${link_name}</body_name>
@@ -106,6 +107,9 @@
       <static>true</static>
       <!-- Ground truth pose-->
       <plugin filename="libignition-gazebo-pose-publisher-system.so" name="ignition::gazebo::systems::PosePublisher">
+        <!-- <ros>
+          <namespace>$(arg namespace)</namespace>
+        </ros> -->
         <publish_link_pose>true</publish_link_pose>
         <publish_nested_model_pose>true</publish_nested_model_pose>   
         <use_pose_vector_msg>true</use_pose_vector_msg>   

--- a/irobot_create_gazebo/irobot_create_gazebo_bringup/launch/create3_gazebo.launch.py
+++ b/irobot_create_gazebo/irobot_create_gazebo_bringup/launch/create3_gazebo.launch.py
@@ -36,7 +36,6 @@ ARGUMENTS = [
                           description='Robot name'),
     DeclareLaunchArgument('namespace', default_value='',
                           description='robot namespace'),
-
         ]
 
 for pose_element in ['x', 'y', 'z', 'yaw']:
@@ -113,6 +112,7 @@ def generate_launch_description():
         # The robot starts docked
         launch_arguments={'x': x_dock, 'y': y, 'z': z, 'yaw': yaw_dock}.items(),
     )
+
     spawn_dock = Node(
         package='gazebo_ros',
         executable='spawn_entity.py',
@@ -140,6 +140,7 @@ def generate_launch_description():
                           'robot_description': namespaced_robot_description,
                           'namespace': namespace,
                           }.items())
+
     # RVIZ2
     rviz2 = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([rviz2_launch_file]),
@@ -154,7 +155,6 @@ def generate_launch_description():
     ld.add_action(gzserver)
     ld.add_action(gzclient)
     # Include robot description
-    # ld.add_action(robot_description)
     ld.add_action(spawn_robot)
     ld.add_action(spawn_dock)
     ld.add_action(dock_description)

--- a/irobot_create_gazebo/irobot_create_gazebo_bringup/launch/create3_gazebo_spawn.launch.py
+++ b/irobot_create_gazebo/irobot_create_gazebo_bringup/launch/create3_gazebo_spawn.launch.py
@@ -1,0 +1,83 @@
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+
+from launch_ros.actions import Node
+
+ARGUMENTS = [
+    DeclareLaunchArgument('gazebo', default_value='classic',
+                          choices=['classic', 'ignition'],
+                          description='Which gazebo simulator to use'),
+    DeclareLaunchArgument('visualize_rays', default_value='false',
+                          choices=['true', 'false'],
+                          description='Enable/disable ray visualization'),
+    DeclareLaunchArgument('robot_name', default_value='create3',
+                          description='Create3 robot name'),
+    DeclareLaunchArgument('robot_description', default_value='robot_description',
+                          description='robot description topic name'),
+    DeclareLaunchArgument('namespace', default_value='',
+                          description='robot namespace'),
+
+]
+
+for pose_element in ['x', 'y', 'z', 'yaw']:
+    ARGUMENTS.append(DeclareLaunchArgument(pose_element, default_value='0.0',
+                     description=f'{pose_element} component of the robot pose.'))
+
+
+def generate_launch_description():
+
+    pkg_create3_common_bringup = get_package_share_directory(
+        'irobot_create_common_bringup')
+    pkg_irobot_create_common_bringup = get_package_share_directory(
+        'irobot_create_common_bringup')
+
+    robot_description_launch = PathJoinSubstitution(
+        [pkg_create3_common_bringup, 'launch', 'robot_description.launch.py'])
+    create3_nodes_launch = PathJoinSubstitution(
+        [pkg_irobot_create_common_bringup, 'launch', 'create3_nodes.launch.py'])
+    robot_description_launch = PathJoinSubstitution(
+        [pkg_irobot_create_common_bringup, 'launch', 'robot_description.launch.py'])
+
+    # Launch configurations
+    x, y, z = LaunchConfiguration('x'), LaunchConfiguration('y'), LaunchConfiguration('z')
+    yaw = LaunchConfiguration('yaw')
+    robot_name = LaunchConfiguration('robot_name')
+    robot_description = LaunchConfiguration('robot_description')
+    namespace = LaunchConfiguration('namespace')
+    gazebo = LaunchConfiguration('gazebo')
+
+    # Spawn robot
+    spawn_robot = Node(
+        package='gazebo_ros',
+        executable='spawn_entity.py',
+        name='spawn_create3',
+        arguments=['-entity', robot_name,
+                   '-topic', robot_description,
+                   '-x', x,
+                   '-y', y,
+                   '-z', z,
+                   '-Y', yaw],
+        output='screen',
+    )
+
+    # Robot description
+    robot_description_launch = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([robot_description_launch]),
+        launch_arguments={'gazebo': gazebo, 'namespace': namespace}.items())
+
+    # Create3 nodes
+    create3_nodes = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([create3_nodes_launch]),
+        launch_arguments=[('namespace', namespace)])
+
+    # Create launch description and add actions
+    ld = LaunchDescription(ARGUMENTS)
+    ld.add_action(spawn_robot)
+    ld.add_action(robot_description_launch)
+    # Include Create 3 nodes
+    ld.add_action(create3_nodes)
+    return ld

--- a/irobot_create_ignition/irobot_create_ignition_bringup/config/pose_republisher_params.yaml
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/config/pose_republisher_params.yaml
@@ -1,5 +1,5 @@
 ---
-pose_republisher_node:
+/**:
   ros__parameters:
     robot_publisher_topic: /sim_ground_truth_pose
     robot_subscriber_topic: /_internal/sim_ground_truth_pose

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition.launch.py
@@ -7,31 +7,15 @@ from pathlib import Path
 
 from ament_index_python.packages import get_package_share_directory
 
-from launch import LaunchContext, LaunchDescription, SomeSubstitutionsType, Substitution
+from irobot_create_common_bringup.offset_parser import OffsetParser
+
+from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
-
-
-class OffsetParser(Substitution):
-    def __init__(
-            self,
-            number: SomeSubstitutionsType,
-            offset: float,
-    ) -> None:
-        self.__number = number
-        self.__offset = offset
-
-    def perform(
-            self,
-            context: LaunchContext = None,
-    ) -> str:
-        number = float(self.__number.perform(context))
-        return f'{number + self.__offset}'
-
 
 ARGUMENTS = [
     DeclareLaunchArgument('bridge', default_value='true',
@@ -49,8 +33,9 @@ ARGUMENTS = [
     DeclareLaunchArgument('spawn_dock', default_value='true',
                           choices=['true', 'false'],
                           description='Spawn the standard dock model.'),
+    DeclareLaunchArgument('namespace', default_value='',
+                          description='robot namespace'),
 ]
-
 for pose_element in ['x', 'y', 'z', 'yaw']:
     ARGUMENTS.append(DeclareLaunchArgument(pose_element, default_value='0.0',
                      description=f'{pose_element} component of the robot pose.'))
@@ -87,22 +72,18 @@ def generate_launch_description():
     # Paths
     ign_gazebo_launch = PathJoinSubstitution(
         [pkg_ros_ign_gazebo, 'launch', 'ign_gazebo.launch.py'])
-    ros_ign_bridge_launch = PathJoinSubstitution(
-        [pkg_irobot_create_ignition_bringup, 'launch', 'create3_ros_ignition_bridge.launch.py'])
-    create3_nodes_launch = PathJoinSubstitution(
-        [pkg_irobot_create_common_bringup, 'launch', 'create3_nodes.launch.py'])
-    create3_ignition_nodes_launch = PathJoinSubstitution(
-        [pkg_irobot_create_ignition_bringup, 'launch', 'create3_ignition_nodes.launch.py'])
-    robot_description_launch = PathJoinSubstitution(
-        [pkg_irobot_create_common_bringup, 'launch', 'robot_description.launch.py'])
     dock_description_launch = PathJoinSubstitution(
         [pkg_irobot_create_common_bringup, 'launch', 'dock_description.launch.py'])
     rviz2_launch = PathJoinSubstitution(
         [pkg_irobot_create_common_bringup, 'launch', 'rviz2.launch.py'])
 
     # Launch configurations
-    x, y, z = LaunchConfiguration('x'), LaunchConfiguration('y'), LaunchConfiguration('z')
+    x, y, z = LaunchConfiguration('x'), LaunchConfiguration(
+        'y'), LaunchConfiguration('z')
     yaw = LaunchConfiguration('yaw')
+    robot_name = LaunchConfiguration('robot_name')
+    namespace = LaunchConfiguration('namespace')
+    namespaced_robot_description = [namespace, '/robot_description']
 
     # Ignition gazebo
     ignition_gazebo = IncludeLaunchDescription(
@@ -120,6 +101,9 @@ def generate_launch_description():
     rviz2 = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([rviz2_launch]),
         condition=IfCondition(LaunchConfiguration('use_rviz')),
+        launch_arguments={  'namespace' : namespace,
+                            'use_namespace' : 'True',
+                        }.items(),
     )
 
     x_dock = OffsetParser(x, 0.157)
@@ -129,23 +113,21 @@ def generate_launch_description():
         condition=IfCondition(LaunchConfiguration('spawn_dock')),
         # The robot starts docked
         launch_arguments={'x': x_dock, 'y': y, 'z': z, 'yaw': yaw_dock,
+                          'namespace' : namespace,
                           'gazebo': 'ignition'}.items(),
     )
 
-    robot_description = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([robot_description_launch]),
-        launch_arguments={'gazebo': 'ignition'}.items()
-    )
-
     # Create3
-    spawn_robot = Node(package='ros_ign_gazebo', executable='create',
-                       arguments=['-name', LaunchConfiguration('robot_name'),
-                                  '-x', x,
-                                  '-y', y,
-                                  '-z', z,
-                                  '-Y', '0.0',
-                                  '-topic', 'robot_description'],
-                       output='screen')
+    spawn_robot = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(os.path.join(pkg_irobot_create_ignition_bringup, 'launch',
+                                                   'create3_spawn.launch.py')),
+        launch_arguments={'x': x,
+                          'y': y,
+                          'z': z,
+                          'robot_name': robot_name,
+                          'robot_description': namespaced_robot_description,
+                          'namespace': namespace,
+                          }.items())
 
     # Dock
     spawn_dock = Node(package='ros_ign_gazebo', executable='create',
@@ -154,37 +136,17 @@ def generate_launch_description():
                                  '-y', y,
                                  '-z', z,
                                  '-Y', '3.141592',
-                                 '-topic', 'standard_dock_description'],
+                                 '-topic', (namespace, '/standard_dock_description')],
                       output='screen')
-
-    # ROS Ign bridge
-    ros_ign_bridge = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([ros_ign_bridge_launch]),
-        launch_arguments=[('world', LaunchConfiguration('world')),
-                          ('robot_name', LaunchConfiguration('robot_name'))]
-    )
-
-    # Create3 nodes
-    create3_nodes = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([create3_nodes_launch])
-    )
-
-    create3_ignition_nodes = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([create3_ignition_nodes_launch]),
-        launch_arguments=[('robot_name', LaunchConfiguration('robot_name'))]
-    )
 
     # Create launch description and add actions
     ld = LaunchDescription(ARGUMENTS)
     ld.add_action(ign_resource_path)
     ld.add_action(ign_gui_plugin_path)
     ld.add_action(ignition_gazebo)
-    ld.add_action(ros_ign_bridge)
     ld.add_action(rviz2)
-    ld.add_action(robot_description)
     ld.add_action(dock_description)
     ld.add_action(spawn_robot)
     ld.add_action(spawn_dock)
-    ld.add_action(create3_nodes)
-    ld.add_action(create3_ignition_nodes)
+
     return ld

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition.launch.py
@@ -82,6 +82,7 @@ def generate_launch_description():
         'y'), LaunchConfiguration('z')
     yaw = LaunchConfiguration('yaw')
     robot_name = LaunchConfiguration('robot_name')
+    world = LaunchConfiguration('world')
     namespace = LaunchConfiguration('namespace')
     namespaced_robot_description = [namespace, '/robot_description']
 
@@ -101,9 +102,7 @@ def generate_launch_description():
     rviz2 = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([rviz2_launch]),
         condition=IfCondition(LaunchConfiguration('use_rviz')),
-        launch_arguments={  'namespace' : namespace,
-                            'use_namespace' : 'True',
-                        }.items(),
+        launch_arguments={'namespace': namespace}.items()
     )
 
     x_dock = OffsetParser(x, 0.157)
@@ -113,8 +112,8 @@ def generate_launch_description():
         condition=IfCondition(LaunchConfiguration('spawn_dock')),
         # The robot starts docked
         launch_arguments={'x': x_dock, 'y': y, 'z': z, 'yaw': yaw_dock,
-                          'namespace' : namespace,
-                          'gazebo': 'ignition'}.items(),
+                          'namespace': namespace,
+                          'gazebo': 'ignition'}.items()
     )
 
     # Create3
@@ -126,8 +125,10 @@ def generate_launch_description():
                           'z': z,
                           'robot_name': robot_name,
                           'robot_description': namespaced_robot_description,
+                          'world' : world,
                           'namespace': namespace,
-                          }.items())
+                          }.items()
+    )
 
     # Dock
     spawn_dock = Node(package='ros_ign_gazebo', executable='create',

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition_nodes.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition_nodes.launch.py
@@ -10,7 +10,9 @@ from launch_ros.actions import Node
 
 ARGUMENTS = [
     DeclareLaunchArgument('robot_name', default_value='create3',
-                          description='Robot name')
+                          description='Robot name'),
+    DeclareLaunchArgument('namespace', default_value='',
+                          description='Robot namespace')
 ]
 
 
@@ -24,10 +26,13 @@ def generate_launch_description():
     sensors_params_yaml_file = PathJoinSubstitution(
         [pkg_create3_ignition_bringup, 'config', 'sensors_params.yaml'])
 
+    namespace = LaunchConfiguration('namespace')
+
     # Pose republisher
     pose_republisher_node = Node(
         package='irobot_create_ignition_toolbox',
         name='pose_republisher_node',
+        namespace=namespace,
         executable='pose_republisher_node',
         parameters=[pose_republisher_params_yaml_file,
                     {'robot_name': LaunchConfiguration('robot_name')},
@@ -39,6 +44,7 @@ def generate_launch_description():
     sensors_node = Node(
         package='irobot_create_ignition_toolbox',
         name='sensors_node',
+        namespace=namespace,
         executable='sensors_node',
         parameters=[sensors_params_yaml_file,
                     {'use_sim_time': True}],
@@ -49,6 +55,7 @@ def generate_launch_description():
     interface_buttons_node = Node(
         package='irobot_create_ignition_toolbox',
         name='interface_buttons_node',
+        namespace=namespace,
         executable='interface_buttons_node',
         parameters=[{'use_sim_time': True}],
         output='screen',

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ros_ignition_bridge.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ros_ignition_bridge.launch.py
@@ -15,12 +15,14 @@ ARGUMENTS = [
     DeclareLaunchArgument('robot_name', default_value='create3',
                           description='Ignition model name'),
     DeclareLaunchArgument('world', default_value='depot',
-                          description='World name')
+                          description='World name'),
+    DeclareLaunchArgument('namespace', default_value='',
+                          description='Robot namespace')
 ]
 
 
 def generate_launch_description():
-    namespace = LaunchConfiguration('robot_name')
+    namespace = LaunchConfiguration('namespace')
     use_sim_time = LaunchConfiguration('use_sim_time')
 
     cliff_sensors = [
@@ -53,18 +55,19 @@ def generate_launch_description():
     # cmd_vel bridge
     cmd_vel_bridge = Node(package='ros_ign_bridge', executable='parameter_bridge',
                           name='cmd_vel_bridge',
+                          namespace=namespace,
                           output='screen',
                           parameters=[{
                               'use_sim_time': use_sim_time
                           }],
                           arguments=[
-                              '/cmd_vel' + '@geometry_msgs/msg/Twist' + '[ignition.msgs.Twist',
-                              ['/model/', LaunchConfiguration('robot_name'), '/cmd_vel' +
+                              ['/',namespace, '/cmd_vel' + '@geometry_msgs/msg/Twist' + '[ignition.msgs.Twist'],
+                              ['/model/', LaunchConfiguration('robot_name'), 'cmd_vel'+
                                '@geometry_msgs/msg/Twist' +
                                ']ignition.msgs.Twist']
                           ],
                           remappings=[
-                              (['/model/', LaunchConfiguration('robot_name'), '/cmd_vel'],
+                              (['/model/', LaunchConfiguration('robot_name'), 'cmd_vel'],
                                'diffdrive_controller/cmd_vel_unstamped')
                           ])
 

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_spawn.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_spawn.launch.py
@@ -1,0 +1,104 @@
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+
+from launch_ros.actions import Node
+
+ARGUMENTS = [
+    DeclareLaunchArgument('gazebo', default_value='classic',
+                          choices=['classic', 'ignition'],
+                          description='Which gazebo simulator to use'),
+    DeclareLaunchArgument('visualize_rays', default_value='false',
+                          choices=['true', 'false'],
+                          description='Enable/disable ray visualization'),
+    DeclareLaunchArgument('robot_name', default_value='create3',
+                          description='Create3 robot name'),
+    DeclareLaunchArgument('robot_description', default_value='robot_description',
+                          description='robot description topic name'),
+    DeclareLaunchArgument('namespace', default_value='',
+                          description='Robot namespace')
+]
+
+for pose_element in ['x', 'y', 'z', 'yaw']:
+    ARGUMENTS.append(DeclareLaunchArgument(pose_element, default_value='0.0',
+                     description=f'{pose_element} component of the robot pose.'))
+
+
+def generate_launch_description():
+
+    pkg_create3_common_bringup = get_package_share_directory(
+        'irobot_create_common_bringup')
+    pkg_irobot_create_common_bringup = get_package_share_directory(
+        'irobot_create_common_bringup')
+    pkg_irobot_create_ignition_bringup = get_package_share_directory(
+        'irobot_create_ignition_bringup')
+
+    robot_description_launch = PathJoinSubstitution(
+        [pkg_create3_common_bringup, 'launch', 'robot_description.launch.py'])
+    ros_ign_bridge_launch = PathJoinSubstitution(
+        [pkg_irobot_create_ignition_bringup, 'launch', 'create3_ros_ignition_bridge.launch.py'])
+    create3_nodes_launch = PathJoinSubstitution(
+        [pkg_irobot_create_common_bringup, 'launch', 'create3_nodes.launch.py'])
+    create3_ignition_nodes_launch = PathJoinSubstitution(
+        [pkg_irobot_create_ignition_bringup, 'launch', 'create3_ignition_nodes.launch.py'])
+    robot_description_launch = PathJoinSubstitution(
+        [pkg_irobot_create_common_bringup, 'launch', 'robot_description.launch.py'])
+
+    # Launch configurations
+    x, y, z = LaunchConfiguration('x'), LaunchConfiguration(
+        'y'), LaunchConfiguration('z')
+    yaw = LaunchConfiguration('yaw')
+    robot_name = LaunchConfiguration('robot_name')
+    robot_description = LaunchConfiguration('robot_description')
+    namespace = LaunchConfiguration('namespace')
+
+    # Spawn robot
+    spawn_robot = Node(
+            package='ros_ign_gazebo',
+            executable='create',
+            output='screen',
+            arguments=[
+                '-name', robot_name,
+                '-topic', robot_description,
+                '-Y', yaw,
+                '-x', x,
+                '-y', y,
+                '-z', z])
+
+    # Robot description
+    robot_description_launch = IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([robot_description_launch]),
+            launch_arguments={'gazebo': 'ignition', 'namespace': namespace}.items())
+
+    # ROS Ign bridge
+    ros_ign_bridge = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([ros_ign_bridge_launch]),
+        launch_arguments=[('world', LaunchConfiguration('world')),
+                          ('robot_name', robot_name),
+                          ('namespace', namespace)]
+
+    )
+
+    # Create3 nodes
+    create3_nodes = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([create3_nodes_launch]),
+        launch_arguments=[('namespace', namespace)]
+                )
+
+    create3_ignition_nodes = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([create3_ignition_nodes_launch]),
+        launch_arguments=[('robot_name', LaunchConfiguration('robot_name')),
+                          ('namespace', namespace)]
+    )
+
+    # Create launch description and add actions
+    ld = LaunchDescription(ARGUMENTS)
+    ld.add_action(spawn_robot)
+    ld.add_action(ros_ign_bridge)
+    ld.add_action(robot_description_launch)
+    ld.add_action(create3_nodes)
+    ld.add_action(create3_ignition_nodes)
+    return ld

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_spawn.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_spawn.launch.py
@@ -8,12 +8,14 @@ from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 
 ARGUMENTS = [
-    DeclareLaunchArgument('gazebo', default_value='classic',
+    DeclareLaunchArgument('gazebo', default_value='ignition',
                           choices=['classic', 'ignition'],
                           description='Which gazebo simulator to use'),
     DeclareLaunchArgument('visualize_rays', default_value='false',
                           choices=['true', 'false'],
                           description='Enable/disable ray visualization'),
+    DeclareLaunchArgument('world', default_value='depot',
+                          description='World name'),
     DeclareLaunchArgument('robot_name', default_value='create3',
                           description='Create3 robot name'),
     DeclareLaunchArgument('robot_description', default_value='robot_description',
@@ -44,16 +46,14 @@ def generate_launch_description():
         [pkg_irobot_create_common_bringup, 'launch', 'create3_nodes.launch.py'])
     create3_ignition_nodes_launch = PathJoinSubstitution(
         [pkg_irobot_create_ignition_bringup, 'launch', 'create3_ignition_nodes.launch.py'])
-    robot_description_launch = PathJoinSubstitution(
-        [pkg_irobot_create_common_bringup, 'launch', 'robot_description.launch.py'])
 
     # Launch configurations
     x, y, z = LaunchConfiguration('x'), LaunchConfiguration(
         'y'), LaunchConfiguration('z')
     yaw = LaunchConfiguration('yaw')
     robot_name = LaunchConfiguration('robot_name')
-    robot_description = LaunchConfiguration('robot_description')
     namespace = LaunchConfiguration('namespace')
+    namespaced_robot_description = [namespace, '/robot_description']
 
     # Spawn robot
     spawn_robot = Node(
@@ -62,7 +62,7 @@ def generate_launch_description():
             output='screen',
             arguments=[
                 '-name', robot_name,
-                '-topic', robot_description,
+                '-topic', namespaced_robot_description,
                 '-Y', yaw,
                 '-x', x,
                 '-y', y,
@@ -79,7 +79,6 @@ def generate_launch_description():
         launch_arguments=[('world', LaunchConfiguration('world')),
                           ('robot_name', robot_name),
                           ('namespace', namespace)]
-
     )
 
     # Create3 nodes


### PR DESCRIPTION
## Description

Hi,
A colleague of mine contacted the turtlebot4 repository to see if it was possible to do multi robot simulation with it. From what @roni-kreinin said it is not possible yet. [turtlebot4 issue](https://github.com/turtlebot/turtlebot4_simulator/issues/10)
We started working on it, starting from the create3, and we're hoping somebody can give us some help as we are running into issues.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

We modified files to make every namespace generic and this works if you spawn 1 robot including namespace cmd_vel, but as soon as you try to spawn a 2nd one it segment faults at launch

![z1g4kEQ](https://user-images.githubusercontent.com/10075496/163203623-84a40b64-f92a-42ac-859d-098b68ee1bd2.png)

It's difficult to find best practices for multi-robot simulation, so we're hoping the way we started is good.
It has only been tested for ignition, I can test for Classic once it works, as well as verify it doesn't break anything else.

```bash
# Run this command
ros2 launch irobot_create_ignition_bringup create3_multi.launch.py
```

## Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
