### PR TITLE
fix dependency tree of create 3 sim packages

### DIFF
--- a/irobot_create_common/irobot_create_control/package.xml
+++ b/irobot_create_common/irobot_create_control/package.xml
@@ -11,20 +11,14 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <exec_depend>gazebo_ros2_control</exec_depend>
-  <exec_depend>ign_ros2_control</exec_depend>
-  <exec_depend>irobot_create_nodes</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
   <exec_depend>ros2launch</exec_depend>
   <exec_depend>ros2_controllers</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_cmake_cppcheck</test_depend>
-  <test_depend>ament_cmake_cpplint</test_depend>
   <test_depend>ament_cmake_flake8</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
   <test_depend>ament_cmake_pep257</test_depend>
-  <test_depend>ament_cmake_uncrustify</test_depend>
   <test_depend>ament_cmake_xmllint</test_depend>
 
   <export>

--- a/irobot_create_common/irobot_create_description/package.xml
+++ b/irobot_create_common/irobot_create_description/package.xml
@@ -12,17 +12,9 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <exec_depend>urdf</exec_depend>
-  <exec_depend>xacro</exec_depend>
-  <exec_depend>irobot_create_control</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_cmake_cppcheck</test_depend>
-  <test_depend>ament_cmake_cpplint</test_depend>
-  <test_depend>ament_cmake_flake8</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>
-  <test_depend>ament_cmake_pep257</test_depend>
-  <test_depend>ament_cmake_uncrustify</test_depend>
-  <test_depend>ament_cmake_xmllint</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/irobot_create_gazebo/irobot_create_gazebo_bringup/package.xml
+++ b/irobot_create_gazebo/irobot_create_gazebo_bringup/package.xml
@@ -13,8 +13,8 @@
 
   <exec_depend>gazebo_plugins</exec_depend>
   <exec_depend>gazebo_ros</exec_depend>
+  <exec_depend>gazebo_ros2_control</exec_depend>
   <exec_depend>irobot_create_common_bringup</exec_depend>
-  <exec_depend>irobot_create_control</exec_depend>
   <exec_depend>irobot_create_description</exec_depend>
   <exec_depend>irobot_create_gazebo_plugins</exec_depend>
   <exec_depend>ros2launch</exec_depend>

--- a/irobot_create_gazebo/irobot_create_gazebo_sim/package.xml
+++ b/irobot_create_gazebo/irobot_create_gazebo_sim/package.xml
@@ -15,10 +15,6 @@
 
   <exec_depend>irobot_create_gazebo_bringup</exec_depend>
   <exec_depend>irobot_create_gazebo_plugins</exec_depend>
-  <exec_depend>irobot_create_common_bringup</exec_depend>
-  <exec_depend>irobot_create_control</exec_depend>
-  <exec_depend>irobot_create_description</exec_depend>
-  <exec_depend>irobot_create_nodes</exec_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/irobot_create_ignition/irobot_create_ignition_bringup/package.xml
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/package.xml
@@ -12,11 +12,11 @@
   <!-- Create3 -->
   <exec_depend>irobot_create_description</exec_depend>
   <exec_depend>irobot_create_common_bringup</exec_depend>
-  <exec_depend>irobot_create_nodes</exec_depend>
   <exec_depend>irobot_create_ignition_toolbox</exec_depend>
   <exec_depend>irobot_create_ignition_plugins</exec_depend>
 
   <!-- ROS IGN -->
+  <exec_depend>ign_ros2_control</exec_depend>
   <exec_depend>ros_ign_interfaces</exec_depend>
   <exec_depend>ros_ign_gazebo</exec_depend>
   <exec_depend>ros_ign_bridge</exec_depend>

--- a/irobot_create_ignition/irobot_create_ignition_sim/package.xml
+++ b/irobot_create_ignition/irobot_create_ignition_sim/package.xml
@@ -13,9 +13,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <exec_depend>irobot_create_common_bringup</exec_depend>
-  <exec_depend>irobot_create_description</exec_depend>
-  <exec_depend>irobot_create_nodes</exec_depend>
   <exec_depend>irobot_create_ignition_bringup</exec_depend>
   <exec_depend>irobot_create_ignition_plugins</exec_depend>
   <exec_depend>irobot_create_ignition_toolbox</exec_depend>


### PR DESCRIPTION
Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>

## Description

Fixes dependency tree of the various packages.
In particular this allows to install `irobot_create_description` without pulling in gazebo.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I haven't tested it yet

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
