### PR TITLE
make gazebo classic and ignition build time dependency 

### DIFF
--- a/irobot_create_gazebo/irobot_create_gazebo_bringup/CMakeLists.txt
+++ b/irobot_create_gazebo/irobot_create_gazebo_bringup/CMakeLists.txt
@@ -12,9 +12,8 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 
-find_package(gazebo_dev QUIET)
 find_package(gazebo_ros QUIET)
-if(NOT gazebo_dev_FOUND OR NOT gazebo_ros_FOUND)
+if(NOT gazebo_ros_FOUND)
   message(WARNING "Gazebo not found. Skipping ${PROJECT_NAME} package.")
   ament_package()
   return()

--- a/irobot_create_gazebo/irobot_create_gazebo_bringup/package.xml
+++ b/irobot_create_gazebo/irobot_create_gazebo_bringup/package.xml
@@ -11,8 +11,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>gazebo_ros</depend>
+
   <exec_depend>gazebo_plugins</exec_depend>
-  <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>gazebo_ros2_control</exec_depend>
   <exec_depend>irobot_create_common_bringup</exec_depend>
   <exec_depend>irobot_create_description</exec_depend>

--- a/irobot_create_ignition/irobot_create_ignition_bringup/package.xml
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/package.xml
@@ -9,6 +9,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <depend>ros_ign_interfaces</depend>
+
   <!-- Create3 -->
   <exec_depend>irobot_create_description</exec_depend>
   <exec_depend>irobot_create_common_bringup</exec_depend>
@@ -17,7 +19,6 @@
 
   <!-- ROS IGN -->
   <exec_depend>ign_ros2_control</exec_depend>
-  <exec_depend>ros_ign_interfaces</exec_depend>
   <exec_depend>ros_ign_gazebo</exec_depend>
   <exec_depend>ros_ign_bridge</exec_depend>
 

--- a/irobot_create_ignition/irobot_create_ignition_plugins/package.xml
+++ b/irobot_create_ignition/irobot_create_ignition_plugins/package.xml
@@ -8,7 +8,8 @@
   <license>BSD</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>ignition-gui5</buildtool_depend>
+
+  <depend>ignition-gui5</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_cppcheck</test_depend>


### PR DESCRIPTION
make gazebo classic and ignition build time dependency if they are needed by CMakeLists.txt

Fixes problems during debian build of packages