### PR TITLE
add missing dependency to irobot-create-common-bringup

### DIFF
--- a/irobot_create_common/irobot_create_common_bringup/package.xml
+++ b/irobot_create_common/irobot_create_common_bringup/package.xml
@@ -13,6 +13,7 @@
 
   <exec_depend>irobot_create_control</exec_depend>
   <exec_depend>irobot_create_description</exec_depend>
+  <exec_depend>irobot_create_nodes</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>ros2launch</exec_depend>


### PR DESCRIPTION
Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>

## Description

add missing dependency to irobot-create-common-bringup
without it, installing `irobot-create-gazebo-sim` or `irobot-create-ignition-sim` misses installing the `irobot-create-nodes` package which is actually required at runtime