### PR TITLE
Humble fix

### DIFF
--- a/irobot_create_common/irobot_create_common_bringup/launch/create3_nodes.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/create3_nodes.launch.py
@@ -72,7 +72,9 @@ def generate_launch_description():
         package='irobot_create_nodes',
         name='motion_control',
         executable='motion_control',
-        parameters=[{'use_sim_time': True}],
+        parameters=[
+            {'safety_override': 'full'},
+            {'use_sim_time': True}],
         output='screen',
     )
 

--- a/irobot_create_common/irobot_create_description/urdf/dock/ir_emitter.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/dock/ir_emitter.urdf.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
   <xacro:macro name="ir_emitter" params="name parent:=base_link *origin
                                          gazebo
-                                         range
+                                         max_range
                                          aperture
                                          update_rate:=1.0
                                          min_range:=${7*cm2m}
@@ -31,7 +31,7 @@
         <xacro:ray_sensor sensor_name="${name}" gazebo="${gazebo}" 
                       update_rate="${update_rate}" visualize="${visualize}" 
                       h_samples="50" h_res="1.0" h_min_angle="-${aperture/2}" h_max_angle="${aperture/2}" 
-                      r_min="${min_range}" r_max="${range}" r_res="0.01">
+                      r_min="${min_range}" r_max="${max_range}" r_res="0.01">
                       <plugin name="dummy" filename="dummyfile"></plugin>
         </xacro:ray_sensor>
       </gazebo>

--- a/irobot_create_common/irobot_create_description/urdf/dock/standard_dock.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/dock/standard_dock.urdf.xacro
@@ -45,7 +45,7 @@
                     parent="${link_name}"
                     gazebo="$(arg gazebo)"
                     aperture="${buoy_lateral_aperture}"
-                    range="1.0"
+                    max_range="1.0"
                     visualize="$(arg visualize_rays)">
     <origin xyz="${buoy_x} 0 ${buoy_z}"
             rpy="0 0 ${- buoy_lateral_angle_yaw}"/>
@@ -56,7 +56,7 @@
                     parent="${link_name}"
                     gazebo="$(arg gazebo)"
                     aperture="${buoy_lateral_aperture}"
-                    range="1.0"
+                    max_range="1.0"
                     visualize="$(arg visualize_rays)">
     <origin xyz="${buoy_x} 0 ${buoy_z}"
             rpy="0 0 ${buoy_lateral_angle_yaw}"/>
@@ -67,7 +67,7 @@
                     parent="${link_name}"
                     gazebo="$(arg gazebo)"
                     aperture="${10*deg2rad}"
-                    range="1.0"
+                    max_range="1.0"
                     visualize="$(arg visualize_rays)">
     <origin xyz="${buoy_x} 0 ${buoy_z}"/>
   </xacro:ir_emitter>
@@ -77,7 +77,7 @@
                     parent="${link_name}"
                     gazebo="$(arg gazebo)"
                     aperture="360"
-                    range="0.6096"
+                    max_range="0.6096"
                     visualize="$(arg visualize_rays)">
     <origin xyz="${buoy_x} 0 ${0.095 - z_offset}"/>
   </xacro:ir_emitter>

--- a/irobot_create_common/irobot_create_nodes/include/irobot_create_nodes/motion_control/docking_behavior.hpp
+++ b/irobot_create_common/irobot_create_nodes/include/irobot_create_nodes/motion_control/docking_behavior.hpp
@@ -6,9 +6,9 @@
 
 #include <stdint.h>
 
-#include <irobot_create_msgs/action/dock_servo.hpp>
+#include <irobot_create_msgs/action/dock.hpp>
 #include <irobot_create_msgs/action/undock.hpp>
-#include <irobot_create_msgs/msg/dock.hpp>
+#include <irobot_create_msgs/msg/dock_status.hpp>
 #include <irobot_create_nodes/motion_control/behaviors_scheduler.hpp>
 #include <irobot_create_nodes/motion_control/simple_goal_controller.hpp>
 #include <nav_msgs/msg/odometry.hpp>
@@ -45,7 +45,7 @@ private:
     const tf2::Transform & docked_robot_pose,
     const tf2::Transform & dock_pose);
 
-  void dock_status_callback(irobot_create_msgs::msg::Dock::ConstSharedPtr msg);
+  void dock_status_callback(irobot_create_msgs::msg::DockStatus::ConstSharedPtr msg);
 
   void robot_pose_callback(nav_msgs::msg::Odometry::ConstSharedPtr msg);
 
@@ -53,19 +53,19 @@ private:
 
   rclcpp_action::GoalResponse handle_dock_servo_goal(
     const rclcpp_action::GoalUUID & uuid,
-    std::shared_ptr<const irobot_create_msgs::action::DockServo::Goal> goal);
+    std::shared_ptr<const irobot_create_msgs::action::Dock::Goal> goal);
 
   rclcpp_action::CancelResponse handle_dock_servo_cancel(
     const std::shared_ptr<
-      rclcpp_action::ServerGoalHandle<irobot_create_msgs::action::DockServo>> goal_handle);
+      rclcpp_action::ServerGoalHandle<irobot_create_msgs::action::Dock>> goal_handle);
 
   void handle_dock_servo_accepted(
     const std::shared_ptr<
-      rclcpp_action::ServerGoalHandle<irobot_create_msgs::action::DockServo>> goal_handle);
+      rclcpp_action::ServerGoalHandle<irobot_create_msgs::action::Dock>> goal_handle);
 
   BehaviorsScheduler::optional_output_t execute_dock_servo(
     const std::shared_ptr<
-      rclcpp_action::ServerGoalHandle<irobot_create_msgs::action::DockServo>> goal_handle,
+      rclcpp_action::ServerGoalHandle<irobot_create_msgs::action::Dock>> goal_handle,
     const RobotState & current_state);
 
   rclcpp_action::GoalResponse handle_undock_goal(
@@ -85,10 +85,10 @@ private:
       rclcpp_action::ServerGoalHandle<irobot_create_msgs::action::Undock>> goal_handle,
     const RobotState & current_state);
 
-  rclcpp_action::Server<irobot_create_msgs::action::DockServo>::SharedPtr docking_action_server_;
+  rclcpp_action::Server<irobot_create_msgs::action::Dock>::SharedPtr docking_action_server_;
   rclcpp_action::Server<irobot_create_msgs::action::Undock>::SharedPtr undocking_action_server_;
 
-  rclcpp::Subscription<irobot_create_msgs::msg::Dock>::SharedPtr dock_status_sub_;
+  rclcpp::Subscription<irobot_create_msgs::msg::DockStatus>::SharedPtr dock_status_sub_;
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr robot_pose_sub_;
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr dock_pose_sub_;
 

--- a/irobot_create_common/irobot_create_nodes/include/irobot_create_nodes/robot_state.hpp
+++ b/irobot_create_common/irobot_create_nodes/include/irobot_create_nodes/robot_state.hpp
@@ -10,7 +10,7 @@
 #include <vector>
 
 #include "geometry_msgs/msg/pose.hpp"
-#include "irobot_create_msgs/msg/dock.hpp"
+#include "irobot_create_msgs/msg/dock_status.hpp"
 #include "irobot_create_msgs/msg/hazard_detection.hpp"
 #include "irobot_create_msgs/msg/hazard_detection_vector.hpp"
 #include "irobot_create_msgs/msg/stop_status.hpp"
@@ -30,7 +30,7 @@ public:
 
 private:
   // Callback functions
-  void dock_callback(irobot_create_msgs::msg::Dock::SharedPtr msg);
+  void dock_callback(irobot_create_msgs::msg::DockStatus::SharedPtr msg);
   void stop_callback(nav_msgs::msg::Odometry::SharedPtr msg);
 
   double get_docked_charge_percentage(const rclcpp::Time & at_time);
@@ -45,7 +45,7 @@ private:
   rclcpp::Publisher<irobot_create_msgs::msg::StopStatus>::SharedPtr stop_status_publisher_{nullptr};
 
   // Subscribers
-  rclcpp::Subscription<irobot_create_msgs::msg::Dock>::SharedPtr dock_subscription_;
+  rclcpp::Subscription<irobot_create_msgs::msg::DockStatus>::SharedPtr dock_subscription_;
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr stop_status_subscription_;
 
   // Topic to publish battery state to

--- a/irobot_create_common/irobot_create_nodes/src/robot_state.cpp
+++ b/irobot_create_common/irobot_create_nodes/src/robot_state.cpp
@@ -55,7 +55,7 @@ RobotState::RobotState(const rclcpp::NodeOptions & options)
     this->declare_parameter("battery_high_percentage", 0.9);
 
   // Subscription to the hazard detection vector
-  dock_subscription_ = create_subscription<irobot_create_msgs::msg::Dock>(
+  dock_subscription_ = create_subscription<irobot_create_msgs::msg::DockStatus>(
     dock_subscription_topic_, rclcpp::SensorDataQoS(),
     std::bind(&RobotState::dock_callback, this, std::placeholders::_1));
   RCLCPP_INFO_STREAM(get_logger(), "Subscription to topic: " << dock_subscription_topic_);
@@ -155,7 +155,7 @@ double RobotState::get_undocked_charge_percentage(const rclcpp::Time & at_time)
   return undocked_charge;
 }
 
-void RobotState::dock_callback(irobot_create_msgs::msg::Dock::SharedPtr msg)
+void RobotState::dock_callback(irobot_create_msgs::msg::DockStatus::SharedPtr msg)
 {
   if (!is_docked_ && msg->is_docked) {
     rclcpp::Time current_time = this->now();

--- a/irobot_create_gazebo/irobot_create_gazebo_plugins/include/irobot_create_gazebo_plugins/gazebo_ros_docking_status.hpp
+++ b/irobot_create_gazebo/irobot_create_gazebo_plugins/include/irobot_create_gazebo_plugins/gazebo_ros_docking_status.hpp
@@ -12,7 +12,7 @@
 #include <gazebo_ros/node.hpp>
 #include <irobot_create_gazebo_plugins/docking_manager.hpp>
 #include <irobot_create_gazebo_plugins/gazebo_ros_helpers.hpp>
-#include <irobot_create_msgs/msg/dock.hpp>
+#include <irobot_create_msgs/msg/dock_status.hpp>
 #include <irobot_create_msgs/msg/ir_opcode.hpp>
 
 #include <cmath>
@@ -64,10 +64,10 @@ private:
   gazebo_ros::Node::SharedPtr ros_node_{nullptr};
 
   /// ROS Dock message
-  irobot_create_msgs::msg::Dock msg_;
+  irobot_create_msgs::msg::DockStatus msg_;
 
   /// ROS publisher
-  rclcpp::Publisher<irobot_create_msgs::msg::Dock>::SharedPtr pub_{nullptr};
+  rclcpp::Publisher<irobot_create_msgs::msg::DockStatus>::SharedPtr pub_{nullptr};
 
   /// ROS Subscription
   rclcpp::Subscription<irobot_create_msgs::msg::IrOpcode>::SharedPtr sub_{nullptr};

--- a/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_docking_status.cpp
+++ b/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_docking_status.cpp
@@ -42,7 +42,7 @@ void GazeboRosDockingStatus::Load(gazebo::physics::ModelPtr model, sdf::ElementP
     dock_model_name, emitter_link_name);
 
   // Initialize ROS publisher
-  pub_ = ros_node_->create_publisher<irobot_create_msgs::msg::Dock>(
+  pub_ = ros_node_->create_publisher<irobot_create_msgs::msg::DockStatus>(
     "~/out", rclcpp::SensorDataQoS().reliable());
 
   sub_ = ros_node_->create_subscription<irobot_create_msgs::msg::IrOpcode>(

--- a/irobot_create_ignition/irobot_create_ignition_toolbox/include/irobot_create_ignition_toolbox/sensors/ir_opcode.hpp
+++ b/irobot_create_ignition/irobot_create_ignition_toolbox/include/irobot_create_ignition_toolbox/sensors/ir_opcode.hpp
@@ -14,7 +14,7 @@
 #include <memory>
 
 #include "irobot_create_msgs/msg/ir_opcode.hpp"
-#include "irobot_create_msgs/msg/dock.hpp"
+#include "irobot_create_msgs/msg/dock_status.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "irobot_create_ignition_toolbox/utils.hpp"
 #include "irobot_create_toolbox/polar_coordinates.hpp"
@@ -75,7 +75,7 @@ private:
   rclcpp::TimerBase::SharedPtr dock_status_timer_;
 
   rclcpp::Publisher<irobot_create_msgs::msg::IrOpcode>::SharedPtr ir_opcode_pub_;
-  rclcpp::Publisher<irobot_create_msgs::msg::Dock>::SharedPtr dock_pub_;
+  rclcpp::Publisher<irobot_create_msgs::msg::DockStatus>::SharedPtr dock_pub_;
 
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr emitter_pose_sub_;
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr receiver_pose_sub_;

--- a/irobot_create_ignition/irobot_create_ignition_toolbox/src/sensors/ir_opcode.cpp
+++ b/irobot_create_ignition/irobot_create_ignition_toolbox/src/sensors/ir_opcode.cpp
@@ -28,7 +28,7 @@ IrOpcode::IrOpcode(std::shared_ptr<rclcpp::Node> & nh)
     "ir_opcode",
     rclcpp::SensorDataQoS());
 
-  dock_pub_ = nh_->create_publisher<irobot_create_msgs::msg::Dock>(
+  dock_pub_ = nh_->create_publisher<irobot_create_msgs::msg::DockStatus>(
     "dock",
     rclcpp::SensorDataQoS());
 
@@ -99,7 +99,7 @@ IrOpcode::IrOpcode(std::shared_ptr<rclcpp::Node> & nh)
         irobot_create_msgs::msg::IrOpcode::SENSOR_DIRECTIONAL_FRONT] !=
       irobot_create_msgs::msg::IrOpcode::CODE_IR_VIRTUAL_WALL;
 
-      auto dock_msg = irobot_create_msgs::msg::Dock();
+      auto dock_msg = irobot_create_msgs::msg::DockStatus();
       dock_msg.header.stamp = nh_->now();
       dock_msg.is_docked = is_docked_;
       dock_msg.dock_visible = is_dock_visible_;


### PR DESCRIPTION
## Description

This PR fixes:
* ir_emitter to avoid global `range` redefinition
* lets the robot move backward by  setting `safety_override` to `full`
*  Messages names after https://github.com/iRobotEducation/irobot_create_msgs/pull/10

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Correct execution in Gazebo.

```bash
# Run this command
ros2 launch irobot_create_gazebo_bringup create3_gazebo.launch.py
```

## Checklist

- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
