### PR TITLE
update to rolling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
       - uses: actions/checkout@v2.3.4
       - uses: ros-tooling/setup-ros@0.4.1
         with:
-          required-ros-distributions: humble
+          required-ros-distributions: rolling
       - uses: ros-tooling/action-ros-ci@0.2.7
         id: action_ros_ci_step
         with:
-          target-ros2-distro: humble
+          target-ros2-distro: rolling
           import-token: ${{ secrets.REPO_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Have a look at the [Create® 3 documentation](https://iroboteducation.github.io/
 
 Required dependencies:
 
-1. [ROS 2 humble](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html)
+1. [ROS 2 rolling](https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html)
 2. ROS 2 dev tools:
     - [colcon-common-extensions](https://pypi.org/project/colcon-common-extensions/)
     - [rosdep](https://pypi.org/project/rosdep/): Used to install dependencies when building from sources

--- a/irobot_create_ignition/irobot_create_ignition_bringup/package.xml
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/package.xml
@@ -18,8 +18,7 @@
   <exec_depend>irobot_create_ignition_plugins</exec_depend>
 
   <!-- ROS IGN -->
-  <!-- ign_ros2_control is required, but it's commented out because not available in Humble-->
-  <!-- <exec_depend>ign_ros2_control</exec_depend> -->
+  <exec_depend>ign_ros2_control</exec_depend>
   <exec_depend>ros_ign_gazebo</exec_depend>
   <exec_depend>ros_ign_bridge</exec_depend>
 


### PR DESCRIPTION
Signed-off-by: Alberto Soragna <alberto.soragna@gmail.com>

## Description

Updates the repository to ROS 2 rolling

Fixes # (issue).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested gazebo classic and ignition.
Gazebo ignition requires to build the ign_ros2_control package from sources, due to https://github.com/ros-controls/gz_ros2_control/issues/105

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
