### PR TITLE
Description fixes

### DIFF
--- a/irobot_create_common/irobot_create_common_bringup/launch/robot_description.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/robot_description.launch.py
@@ -48,11 +48,47 @@ def generate_launch_description():
         output='screen',
     )
 
+    left_wheel_drop_stf = Node(
+            name='left_wheel_drop_stf',
+            package='tf2_ros',
+            executable='static_transform_publisher',
+            output='screen',
+            arguments=[
+                '--x', '0.0',
+                '--y', '0.1165',
+                '--z', '0.0402',
+                '--roll', '-1.5707',
+                '--pitch', '0.0',
+                '--yaw', '0.0',
+                '--frame-id', 'base_link',
+                '--child-frame-id', 'wheel_drop_left',
+            ]
+        )
+
+    right_wheel_drop_stf = Node(
+            name='right_wheel_drop_stf',
+            package='tf2_ros',
+            executable='static_transform_publisher',
+            output='screen',
+            arguments=[
+                '--x', '0.0',
+                '--y', '-0.1165',
+                '--z', '0.0402',
+                '--roll', '-1.5707',
+                '--pitch', '0.0',
+                '--yaw', '0.0',
+                '--frame-id', 'base_link',
+                '--child-frame-id', 'wheel_drop_right',
+            ]
+        )
+
     # Define LaunchDescription variable
     ld = LaunchDescription(ARGUMENTS)
 
     # Add nodes to LaunchDescription
     ld.add_action(joint_state_publisher)
     ld.add_action(robot_state_publisher)
+    ld.add_action(left_wheel_drop_stf)
+    ld.add_action(right_wheel_drop_stf)
 
     return ld

--- a/irobot_create_common/irobot_create_description/urdf/bumper.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/bumper.urdf.xacro
@@ -15,7 +15,7 @@ functional, while the 4 remaining ones are created as dummy links. -->
   <link name="${link_name}"/>
 </xacro:macro>
 
-<xacro:macro name="bumper" params="name:=bump_front_center parent_link:=base_link update_rate:=62.0 gazebo visual_mesh collision_mesh
+<xacro:macro name="bumper" params="name:=bumper parent_link:=base_link update_rate:=62.0 gazebo visual_mesh collision_mesh
   *origin *inertial">
   <xacro:property name="link_name" value="${name}"/>
   <xacro:property name="joint_name" value="${name}_joint"/>
@@ -66,6 +66,11 @@ functional, while the 4 remaining ones are created as dummy links. -->
   <gazebo reference="${joint_name}">
     <preserveFixedJoint>true</preserveFixedJoint>
   </gazebo>
+
+  <xacro:dummy_bumper_zone
+      name="bump_front_center">
+      <origin xyz="0.175 0 0.039" rpy="0 0 0"/>
+  </xacro:dummy_bumper_zone>
 
   <xacro:dummy_bumper_zone
       name="bump_front_left">


### PR DESCRIPTION
## Description

For the bumper I have renamed the main link that sets the visual and collision to "bumper" and added a "bump_front_center" dummy link for the front center bump sensor. This way the transform published by the robot does not offset the bumper mesh.

For the wheel drops I added a static transform publisher for each wheel.

Fixes #125 and #170.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tested on physical robot. RVIZ no longer shows the wheel drop error and the bumper is in the correct position.

![image](https://user-images.githubusercontent.com/59886299/218163270-d68ed013-29d5-4e38-9ae0-2d81a380ab81.png)

![image](https://user-images.githubusercontent.com/59886299/218163619-28d1d1c7-9e23-41fd-be49-d33683a621d7.png)


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
