### PR TITLE
Remap odom topic

### DIFF
--- a/irobot_create_common/irobot_create_description/urdf/create3.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/create3.urdf.xacro
@@ -117,6 +117,9 @@
     <gazebo>
       <plugin name="gazebo_ros2_control" filename="libgazebo_ros2_control.so">
         <parameters> $(find irobot_create_control)/config/control.yaml </parameters>
+        <ros>
+          <remapping>~/odom:=odom</remapping>
+        </ros>
       </plugin>
     </gazebo>
   </xacro:if>
@@ -125,6 +128,9 @@
     <gazebo>
       <plugin filename="libign_ros2_control-system.so" name="ign_ros2_control::IgnitionROS2ControlPlugin">
         <parameters> $(find irobot_create_control)/config/control.yaml </parameters>
+        <ros>
+          <remapping>~/odom:=odom</remapping>
+        </ros>
       </plugin>
     </gazebo>
   </xacro:if>


### PR DESCRIPTION
## Description

Default odom topic in `diffdrive_controller` was changed in humble from `/odom` to `~/odom`.
Added a remap to revert back to using `/odom` for compatibility with `motion_control_node` and `robot_state`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Also list any relevant details for your test configuration.

```bash
# Run this command
ros2 launch irobot_create_ignition_bringup create3_ignition.launch.py
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
