### PR TITLE
Multi robot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 This is a ROS 2 simulation stack for the [iRobot® Create® 3](https://edu.irobot.com/create3) robot.
 Both Ignition Gazebo and Classic Gazebo are supported.
 
-> :warning: **To run with Ignition Gazebo you must first build and install the [`gz_ros2_control`](https://github.com/ros-controls/gz_ros2_control) package master branch from sources!**
-
 Have a look at the [Create® 3 documentation](https://iroboteducation.github.io/create3_docs/) for more details on the ROS 2 interfaces exposed by the robot.
 
 ## Prerequisites
@@ -66,11 +64,34 @@ source install/local_setup.bash
 
 ##### Empty world
 
-Create® 3 can be spawned in an empty world in Gazebo and monitored through RViz with
+Create® 3 can be spawned in an empty world in Gazebo and monitored through RViz with:
 
 ```bash
 ros2 launch irobot_create_gazebo_bringup create3_gazebo.launch.py
 ```
+
+The spawn point can be changed with the `x`, `y`, `z` and `yaw` launch arguments:
+
+```bash
+ros2 launch irobot_create_gazebo_bringup create3_gazebo.launch.py x:=1.0 y:=0.5 yaw:=1.5707
+```
+
+##### Namespacing
+
+A namespace can be applied to the robot using the `namespace` launch argument:
+
+```bash
+ros2 launch irobot_create_gazebo_bringup create3_gazebo.launch.py namespace:=my_robot
+```
+
+Multiple robots can be spawned with unique namespaces:
+
+```bash
+ros2 launch irobot_create_gazebo_bringup create3_gazebo.launch.py namespace:=robot1
+ros2 launch irobot_create_gazebo_bringup create3_spawn.launch.py namespace:=robot2 x:=1.0
+```
+
+> :warning: `create3_gazebo.launch.py` should only be used once as it launches the Gazebo simulator itself. Additional robots should be spawned with `create3_spawn.launch.py`. Namespaces and spawn points should be unique for each robot.
 
 ##### AWS house
 
@@ -98,6 +119,29 @@ Create® 3 can be spawned in a demo world in Ignition and monitored through RViz
 ```bash
 ros2 launch irobot_create_ignition_bringup create3_ignition.launch.py
 ```
+
+The spawn point can be changed with the `x`, `y`, `z` and `yaw` launch arguments:
+
+```bash
+ros2 launch irobot_create_ignition_bringup create3_ignition.launch.py x:=1.0 y:=0.5 yaw:=1.5707
+```
+
+##### Namespacing
+
+A namespace can be applied to the robot using the `namespace` launch argument:
+
+```bash
+ros2 launch irobot_create_ignition_bringup create3_ignition.launch.py namespace:=my_robot
+```
+
+Multiple robots can be spawned with unique namespaces:
+
+```bash
+ros2 launch irobot_create_ignition_bringup create3_ignition.launch.py namespace:=robot1
+ros2 launch irobot_create_ignition_bringup create3_spawn.launch.py namespace:=robot2 x:=1.0
+```
+
+> :warning: `create3_ignition.launch.py` should only be used once as it launches the Ignition simulator itself. Additional robots should be spawned with `create3_spawn.launch.py`. Namespaces and spawn points should be unique for each robot.
 
 ## Package layout
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Besides the aforementioned dependencies you will also need at least one among Ig
 
 Install [Gazebo 11](http://gazebosim.org/tutorials?tut=install_ubuntu)
 
-#### Ignition Edifice
+#### Ignition Fortress
 
 ```bash
 sudo apt-get update && sudo apt-get install wget
 sudo sh -c 'echo "deb http://packages.osrfoundation.org/gazebo/ubuntu-stable `lsb_release -cs` main" > /etc/apt/sources.list.d/gazebo-stable.list'
 wget http://packages.osrfoundation.org/gazebo.key -O - | sudo apt-key add -
-sudo apt-get update && sudo apt-get install ignition-edifice
+sudo apt-get update && sudo apt-get install ignition-fortress
 ```
 
 ## Build
@@ -55,7 +55,7 @@ rosdep install --from-path src -yi
 - Build the workspace with:
 
 ```bash
-export IGNITION_VERSION=edifice
+export IGNITION_VERSION=fortress
 colcon build --symlink-install
 source install/local_setup.bash
 ```

--- a/irobot_create_common/irobot_create_common_bringup/CMakeLists.txt
+++ b/irobot_create_common/irobot_create_common_bringup/CMakeLists.txt
@@ -11,6 +11,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
 
 install(
   DIRECTORY
@@ -20,6 +21,9 @@ install(
   DESTINATION
     share/${PROJECT_NAME}
 )
+
+# Install Python modules
+ament_python_install_package(${PROJECT_NAME})
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/irobot_create_common/irobot_create_common_bringup/config/hazard_vector_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/hazard_vector_params.yaml
@@ -2,7 +2,7 @@
 hazards_vector_publisher:
   ros__parameters:
     # Hazard detection publisher topic
-    publisher_topic: /hazard_detection
+    publisher_topic: hazard_detection
     publish_rate: 62.0
     subscription_topics:
       # Bumper topic

--- a/irobot_create_common/irobot_create_common_bringup/config/hazard_vector_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/hazard_vector_params.yaml
@@ -1,19 +1,20 @@
 ---
-hazards_vector_publisher:
-  ros__parameters:
-    # Hazard detection publisher topic
-    publisher_topic: hazard_detection
-    publish_rate: 62.0
-    subscription_topics:
-      # Bumper topic
-      - _internal/bumper/event
-      # Cliff topics
-      - _internal/cliff_front_left/event
-      - _internal/cliff_front_right/event
-      - _internal/cliff_side_left/event
-      - _internal/cliff_side_right/event
-      # Wheel drop topics
-      - _internal/wheel_drop/left_wheel/event
-      - _internal/wheel_drop/right_wheel/event
-      # Backup limit topic
-      - _internal/backup_limit
+/**:
+  hazards_vector_publisher:
+    ros__parameters:
+      # Hazard detection publisher topic
+      publisher_topic: hazard_detection
+      publish_rate: 62.0
+      subscription_topics:
+        # Bumper topic
+        - _internal/bumper/event
+        # Cliff topics
+        - _internal/cliff_front_left/event
+        - _internal/cliff_front_right/event
+        - _internal/cliff_side_left/event
+        - _internal/cliff_side_right/event
+        # Wheel drop topics
+        - _internal/wheel_drop/left_wheel/event
+        - _internal/wheel_drop/right_wheel/event
+        # Backup limit topic
+        - _internal/backup_limit

--- a/irobot_create_common/irobot_create_common_bringup/config/ir_intensity_vector_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/ir_intensity_vector_params.yaml
@@ -2,7 +2,7 @@
 ir_intensity_vector_publisher:
   ros__parameters:
     # IR intensity publisher topic
-    publisher_topic: /ir_intensity
+    publisher_topic: ir_intensity
     publish_rate: 62.0
     subscription_topics:
       # IR intensity topics

--- a/irobot_create_common/irobot_create_common_bringup/config/ir_intensity_vector_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/ir_intensity_vector_params.yaml
@@ -1,15 +1,16 @@
 ---
-ir_intensity_vector_publisher:
-  ros__parameters:
-    # IR intensity publisher topic
-    publisher_topic: ir_intensity
-    publish_rate: 62.0
-    subscription_topics:
-      # IR intensity topics
-      - _internal/ir_intensity_front_center_left
-      - _internal/ir_intensity_front_center_right
-      - _internal/ir_intensity_front_left
-      - _internal/ir_intensity_front_right
-      - _internal/ir_intensity_left
-      - _internal/ir_intensity_right
-      - _internal/ir_intensity_side_left
+/**:
+  ir_intensity_vector_publisher:
+    ros__parameters:
+      # IR intensity publisher topic
+      publisher_topic: ir_intensity
+      publish_rate: 62.0
+      subscription_topics:
+        # IR intensity topics
+        - _internal/ir_intensity_front_center_left
+        - _internal/ir_intensity_front_center_right
+        - _internal/ir_intensity_front_left
+        - _internal/ir_intensity_front_right
+        - _internal/ir_intensity_left
+        - _internal/ir_intensity_right
+        - _internal/ir_intensity_side_left

--- a/irobot_create_common/irobot_create_common_bringup/config/kidnap_estimator_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/kidnap_estimator_params.yaml
@@ -1,7 +1,8 @@
 ---
-kidnap_estimator_publisher:
-  ros__parameters:
-    # Kidnap status publisher topic
-    kidnap_status_topic: kidnap_status
-    # Subscription topics
-    hazard_topic: hazard_detection
+/**:
+  kidnap_estimator_publisher:
+    ros__parameters:
+      # Kidnap status publisher topic
+      kidnap_status_topic: kidnap_status
+      # Subscription topics
+      hazard_topic: hazard_detection

--- a/irobot_create_common/irobot_create_common_bringup/config/kidnap_estimator_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/kidnap_estimator_params.yaml
@@ -2,6 +2,6 @@
 kidnap_estimator_publisher:
   ros__parameters:
     # Kidnap status publisher topic
-    kidnap_status_topic: /kidnap_status
+    kidnap_status_topic: kidnap_status
     # Subscription topics
-    hazard_topic: /hazard_detection
+    hazard_topic: hazard_detection

--- a/irobot_create_common/irobot_create_common_bringup/config/mock_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/mock_params.yaml
@@ -1,7 +1,8 @@
 ---
-mock_publisher:
-  ros__parameters:
-    # Mock slip status publisher topic
-    slip_status_topic: slip_status
-    # Publishers rate
-    slip_status_publish_rate: 62.0
+/**:
+  mock_publisher:
+    ros__parameters:
+      # Mock slip status publisher topic
+      slip_status_topic: slip_status
+      # Publishers rate
+      slip_status_publish_rate: 62.0

--- a/irobot_create_common/irobot_create_common_bringup/config/mock_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/mock_params.yaml
@@ -2,6 +2,6 @@
 mock_publisher:
   ros__parameters:
     # Mock slip status publisher topic
-    slip_status_topic: /slip_status
+    slip_status_topic: slip_status
     # Publishers rate
     slip_status_publish_rate: 62.0

--- a/irobot_create_common/irobot_create_common_bringup/config/robot_state_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/robot_state_params.yaml
@@ -2,16 +2,16 @@
 robot_state:
   ros__parameters:
     # Stop status publisher topic
-    stop_status_topic: /stop_status
+    stop_status_topic: stop_status
     # Mock battery state publisher topic
-    battery_state_topic: /battery_state
+    battery_state_topic: battery_state
     # Publishers rate
     kidnap_status_publish_rate: 1.0
     stop_status_publish_rate: 62.0
     battery_state_publish_rate: 0.1
     # Subscription topics
-    dock_topic: /dock_status
-    wheel_vels_topic: /odom
+    dock_topic: dock_status
+    wheel_vels_topic: odom
     # Stop status position difference tolerance
     linear_velocity_tolerance: 0.01
     angular_velocity_tolerance: 0.1

--- a/irobot_create_common/irobot_create_common_bringup/config/robot_state_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/robot_state_params.yaml
@@ -1,22 +1,23 @@
 ---
-robot_state:
-  ros__parameters:
-    # Stop status publisher topic
-    stop_status_topic: stop_status
-    # Mock battery state publisher topic
-    battery_state_topic: battery_state
-    # Publishers rate
-    kidnap_status_publish_rate: 1.0
-    stop_status_publish_rate: 62.0
-    battery_state_publish_rate: 0.1
-    # Subscription topics
-    dock_topic: dock_status
-    wheel_vels_topic: odom
-    # Stop status position difference tolerance
-    linear_velocity_tolerance: 0.01
-    angular_velocity_tolerance: 0.1
-    # Battery parameters
-    full_charge_percentage: 1.0
-    battery_high_percentage: 0.9
-    # Dock Parameters
-    undocked_charge_limit: 0.03
+/**:
+  robot_state:
+    ros__parameters:
+      # Stop status publisher topic
+      stop_status_topic: stop_status
+      # Mock battery state publisher topic
+      battery_state_topic: battery_state
+      # Publishers rate
+      kidnap_status_publish_rate: 1.0
+      stop_status_publish_rate: 62.0
+      battery_state_publish_rate: 0.1
+      # Subscription topics
+      dock_topic: dock_status
+      wheel_vels_topic: odom
+      # Stop status position difference tolerance
+      linear_velocity_tolerance: 0.01
+      angular_velocity_tolerance: 0.1
+      # Battery parameters
+      full_charge_percentage: 1.0
+      battery_high_percentage: 0.9
+      # Dock Parameters
+      undocked_charge_limit: 0.03

--- a/irobot_create_common/irobot_create_common_bringup/config/ui_mgr_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/ui_mgr_params.yaml
@@ -1,10 +1,11 @@
 ---
-ui_mgr:
-  ros__parameters:
-    # Buttons publisher topic
-    button_topic: interface_buttons
-    # Publishers rate
-    buttons_publish_rate: 1.0
-    # Subscription topics
-    lightring_topic: cmd_lightring
-    audio_topic: cmd_audio
+/**:
+  ui_mgr:
+    ros__parameters:
+      # Buttons publisher topic
+      button_topic: interface_buttons
+      # Publishers rate
+      buttons_publish_rate: 1.0
+      # Subscription topics
+      lightring_topic: cmd_lightring
+      audio_topic: cmd_audio

--- a/irobot_create_common/irobot_create_common_bringup/config/ui_mgr_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/ui_mgr_params.yaml
@@ -2,9 +2,9 @@
 ui_mgr:
   ros__parameters:
     # Buttons publisher topic
-    button_topic: /interface_buttons
+    button_topic: interface_buttons
     # Publishers rate
     buttons_publish_rate: 1.0
     # Subscription topics
-    lightring_topic: /cmd_lightring
-    audio_topic: /cmd_audio
+    lightring_topic: cmd_lightring
+    audio_topic: cmd_audio

--- a/irobot_create_common/irobot_create_common_bringup/config/wheel_status_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/wheel_status_params.yaml
@@ -8,6 +8,6 @@ wheel_status_publisher:
     # Wheel radius
     wheel_radius: 0.03575
     # Wheels angular velocity topic
-    velocity_topic: /wheel_vels
+    velocity_topic: wheel_vels
     # Wheels' net encoder ticks topic
-    ticks_topic: /wheel_ticks
+    ticks_topic: wheel_ticks

--- a/irobot_create_common/irobot_create_common_bringup/config/wheel_status_params.yaml
+++ b/irobot_create_common/irobot_create_common_bringup/config/wheel_status_params.yaml
@@ -1,13 +1,14 @@
 ---
-wheel_status_publisher:
-  ros__parameters:
-    # Publish rate
-    publish_rate: 62.0
-    # Encoder resolution
-    encoder_resolution: 508.8
-    # Wheel radius
-    wheel_radius: 0.03575
-    # Wheels angular velocity topic
-    velocity_topic: wheel_vels
-    # Wheels' net encoder ticks topic
-    ticks_topic: wheel_ticks
+/**:
+  wheel_status_publisher:
+    ros__parameters:
+      # Publish rate
+      publish_rate: 62.0
+      # Encoder resolution
+      encoder_resolution: 508.8
+      # Wheel radius
+      wheel_radius: 0.03575
+      # Wheels angular velocity topic
+      velocity_topic: wheel_vels
+      # Wheels' net encoder ticks topic
+      ticks_topic: wheel_ticks

--- a/irobot_create_common/irobot_create_common_bringup/irobot_create_common_bringup/namespace.py
+++ b/irobot_create_common/irobot_create_common_bringup/irobot_create_common_bringup/namespace.py
@@ -1,0 +1,33 @@
+from typing import Union
+
+from launch import LaunchContext, SomeSubstitutionsType, Substitution
+
+
+class GetNamespacedName(Substitution):
+    def __init__(
+            self,
+            namespace: Union[SomeSubstitutionsType, str],
+            name: Union[SomeSubstitutionsType, str]
+    ) -> None:
+        self.__namespace = namespace
+        self.__name = name
+
+    def perform(
+            self,
+            context: LaunchContext = None,
+    ) -> str:
+        if isinstance(self.__namespace, Substitution):
+            namespace = str(self.__namespace.perform(context))
+        else:
+            namespace = str(self.__namespace)
+
+        if isinstance(self.__name, Substitution):
+            name = str(self.__name.perform(context))
+        else:
+            name = str(self.__name)
+
+        if namespace == '':
+            namespaced_name = name
+        else:
+            namespaced_name = namespace + '/' + name
+        return namespaced_name

--- a/irobot_create_common/irobot_create_common_bringup/irobot_create_common_bringup/offset.py
+++ b/irobot_create_common/irobot_create_common_bringup/irobot_create_common_bringup/offset.py
@@ -1,0 +1,59 @@
+import math
+from typing import Union
+
+from launch import LaunchContext, SomeSubstitutionsType, Substitution
+
+
+class RotationalOffsetX(Substitution):
+    def __init__(
+            self,
+            offset: float,
+            yaw: SomeSubstitutionsType
+    ) -> None:
+        self.__offset = offset
+        self.__yaw = yaw
+
+    def perform(
+            self,
+            context: LaunchContext = None,
+    ) -> str:
+        yaw = float(self.__yaw.perform(context))
+        return f'{self.__offset * math.cos(yaw)}'
+
+
+class RotationalOffsetY(Substitution):
+    def __init__(
+            self,
+            offset: float,
+            yaw: SomeSubstitutionsType
+    ) -> None:
+        self.__offset = offset
+        self.__yaw = yaw
+
+    def perform(
+            self,
+            context: LaunchContext = None,
+    ) -> str:
+        yaw = float(self.__yaw.perform(context))
+        return f'{self.__offset * math.sin(yaw)}'
+
+
+class OffsetParser(Substitution):
+    def __init__(
+            self,
+            number: SomeSubstitutionsType,
+            offset: Union[float, Substitution],
+    ) -> None:
+        self.__number = number
+        self.__offset = offset
+
+    def perform(
+            self,
+            context: LaunchContext = None,
+    ) -> str:
+        number = float(self.__number.perform(context))
+        if isinstance(self.__offset, Substitution):
+            offset = float(self.__offset.perform(context))
+        else:
+            offset = self.__offset
+        return f'{number + offset}'

--- a/irobot_create_common/irobot_create_common_bringup/launch/create3_nodes.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/create3_nodes.launch.py
@@ -14,7 +14,9 @@ from launch_ros.actions import Node
 ARGUMENTS = [
     DeclareLaunchArgument('gazebo', default_value='classic',
                           choices=['classic', 'ignition'],
-                          description='Which gazebo simulator to use')
+                          description='Which gazebo simulator to use'),
+    DeclareLaunchArgument('robot_name', default_value='create3',
+                          description='Robot name'),
 ]
 
 

--- a/irobot_create_common/irobot_create_common_bringup/launch/create3_nodes.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/create3_nodes.launch.py
@@ -15,8 +15,8 @@ ARGUMENTS = [
     DeclareLaunchArgument('gazebo', default_value='classic',
                           choices=['classic', 'ignition'],
                           description='Which gazebo simulator to use'),
-    DeclareLaunchArgument('robot_name', default_value='create3',
-                          description='Robot name'),
+    DeclareLaunchArgument('namespace', default_value='',
+                          description='Robot namespace'),
 ]
 
 
@@ -47,7 +47,7 @@ def generate_launch_description():
     # Includes
     diffdrive_controller = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([control_launch_file]),
-        launch_arguments=[('robot_name', LaunchConfiguration('robot_name'))]
+        launch_arguments=[('namespace', LaunchConfiguration('namespace'))]
     )
 
     # Publish hazards vector

--- a/irobot_create_common/irobot_create_common_bringup/launch/create3_nodes.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/create3_nodes.launch.py
@@ -44,7 +44,8 @@ def generate_launch_description():
 
     # Includes
     diffdrive_controller = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([control_launch_file])
+        PythonLaunchDescriptionSource([control_launch_file]),
+        launch_arguments=[('robot_name', LaunchConfiguration('robot_name'))]
     )
 
     # Publish hazards vector
@@ -74,6 +75,10 @@ def generate_launch_description():
         executable='motion_control',
         parameters=[{'use_sim_time': True}],
         output='screen',
+        remappings=[
+            ('/tf', 'tf'),
+            ('/tf_static', 'tf_static')
+        ]
     )
 
     # Publish wheel status

--- a/irobot_create_common/irobot_create_common_bringup/launch/dock_description.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/dock_description.launch.py
@@ -37,6 +37,7 @@ def generate_launch_description():
     visualize_rays = LaunchConfiguration('visualize_rays')
 
     gazebo_simulator = LaunchConfiguration('gazebo')
+    namespace = LaunchConfiguration('namespace', default='')
 
     state_publisher = Node(
         package='robot_state_publisher',
@@ -53,6 +54,8 @@ def generate_launch_description():
         ],
         remappings=[
             ('robot_description', 'standard_dock_description'),
+            ('/tf', 'tf'),
+            ('/tf_static', 'tf_static')
         ],
     )
 
@@ -64,7 +67,11 @@ def generate_launch_description():
                    # According to documentation (http://wiki.ros.org/tf2_ros):
                    # the order is yaw, pitch, roll
                    yaw, '0', '0',
-                   'odom', 'std_dock_link'],
+                   [namespace, '/odom'], [namespace, '/std_dock_link']],
+        remappings=[
+            ('/tf', 'tf'),
+            ('/tf_static', 'tf_static')
+        ],
         output='screen',
     )
 

--- a/irobot_create_common/irobot_create_common_bringup/launch/dock_description.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/dock_description.launch.py
@@ -37,7 +37,6 @@ def generate_launch_description():
     visualize_rays = LaunchConfiguration('visualize_rays')
 
     gazebo_simulator = LaunchConfiguration('gazebo')
-    namespace = LaunchConfiguration('namespace', default='')
 
     state_publisher = Node(
         package='robot_state_publisher',
@@ -67,7 +66,7 @@ def generate_launch_description():
                    # According to documentation (http://wiki.ros.org/tf2_ros):
                    # the order is yaw, pitch, roll
                    yaw, '0', '0',
-                   [namespace, '/odom'], [namespace, '/std_dock_link']],
+                   'odom', 'std_dock_link'],
         remappings=[
             ('/tf', 'tf'),
             ('/tf_static', 'tf_static')

--- a/irobot_create_common/irobot_create_common_bringup/launch/dock_description.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/dock_description.launch.py
@@ -14,8 +14,8 @@ ARGUMENTS = [
                           choices=['classic', 'ignition'],
                           description='Which gazebo simulation to use'),
     DeclareLaunchArgument('visualize_rays', default_value='true',
-                                       choices=['true', 'false'],
-                                       description='Enable/disable ray visualization')
+                          choices=['true', 'false'],
+                          description='Enable/disable ray visualization')
 ]
 
 

--- a/irobot_create_common/irobot_create_common_bringup/launch/dock_description.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/dock_description.launch.py
@@ -15,7 +15,9 @@ ARGUMENTS = [
                           description='Which gazebo simulation to use'),
     DeclareLaunchArgument('visualize_rays', default_value='true',
                           choices=['true', 'false'],
-                          description='Enable/disable ray visualization')
+                          description='Enable/disable ray visualization'),
+    DeclareLaunchArgument('namespace', default_value='',
+                          description='Robot namespace'),
 ]
 
 
@@ -28,8 +30,8 @@ def generate_launch_description():
 
     # Launch Configurations
     visualize_rays = LaunchConfiguration('visualize_rays')
-
     gazebo_simulator = LaunchConfiguration('gazebo')
+    namespace = LaunchConfiguration('namespace')
 
     state_publisher = Node(
         package='robot_state_publisher',
@@ -42,6 +44,7 @@ def generate_launch_description():
              Command(
                 ['xacro', ' ', dock_xacro_file, ' ',
                  'gazebo:=', gazebo_simulator, ' ',
+                 'namespace:=', namespace, ' ',
                  'visualize_rays:=', visualize_rays])},
         ],
         remappings=[

--- a/irobot_create_common/irobot_create_common_bringup/launch/dock_description.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/dock_description.launch.py
@@ -9,19 +9,14 @@ from launch.actions import DeclareLaunchArgument
 from launch.substitutions import Command, LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 
-
 ARGUMENTS = [
     DeclareLaunchArgument('gazebo', default_value='classic',
                           choices=['classic', 'ignition'],
-                          description='Which gazebo simulation to use')
-]
-for pose_element in ['x', 'y', 'z', 'yaw']:
-    ARGUMENTS.append(DeclareLaunchArgument(f'{pose_element}', default_value='0.0',
-                     description=f'{pose_element} component of the dock pose.'))
-
-ARGUMENTS.append(DeclareLaunchArgument('visualize_rays', default_value='true',
+                          description='Which gazebo simulation to use'),
+    DeclareLaunchArgument('visualize_rays', default_value='true',
                                        choices=['true', 'false'],
-                                       description='Enable/disable ray visualization'))
+                                       description='Enable/disable ray visualization')
+]
 
 
 def generate_launch_description():
@@ -32,8 +27,6 @@ def generate_launch_description():
         [pkg_create3_description, 'urdf', 'dock', 'standard_dock.urdf.xacro'])
 
     # Launch Configurations
-    x, y, z = LaunchConfiguration('x'), LaunchConfiguration('y'), LaunchConfiguration('z')
-    yaw = LaunchConfiguration('yaw')
     visualize_rays = LaunchConfiguration('visualize_rays')
 
     gazebo_simulator = LaunchConfiguration('gazebo')
@@ -62,10 +55,10 @@ def generate_launch_description():
         package='tf2_ros',
         executable='static_transform_publisher',
         name='tf_odom_std_dock_link_publisher',
-        arguments=[x, y, z,
+        arguments=['0.157', '0', '0',
                    # According to documentation (http://wiki.ros.org/tf2_ros):
                    # the order is yaw, pitch, roll
-                   yaw, '0', '0',
+                   '3.141592', '0', '0',
                    'odom', 'std_dock_link'],
         remappings=[
             ('/tf', 'tf'),

--- a/irobot_create_common/irobot_create_common_bringup/launch/robot_description.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/robot_description.launch.py
@@ -20,6 +20,8 @@ ARGUMENTS = [
                           description='Enable/disable ray visualization'),
     DeclareLaunchArgument('robot_name', default_value='create3',
                           description='Robot name'),
+    DeclareLaunchArgument('namespace', default_value=LaunchConfiguration('robot_name'),
+                          description='Robot namespace'),
 ]
 
 
@@ -28,7 +30,7 @@ def generate_launch_description():
     xacro_file = PathJoinSubstitution([pkg_create3_description, 'urdf', 'create3.urdf.xacro'])
     gazebo_simulator = LaunchConfiguration('gazebo')
     visualize_rays = LaunchConfiguration('visualize_rays')
-    robot_name = LaunchConfiguration('robot_name')
+    namespace = LaunchConfiguration('namespace')
 
     robot_state_publisher = Node(
         package='robot_state_publisher',
@@ -42,7 +44,7 @@ def generate_launch_description():
                   ['xacro', ' ', xacro_file, ' ',
                    'gazebo:=', gazebo_simulator, ' ',
                    'visualize_rays:=', visualize_rays, ' ',
-                   'namespace:=', robot_name])},
+                   'namespace:=', namespace])},
         ],
         remappings=[
             ('/tf', 'tf'),

--- a/irobot_create_common/irobot_create_common_bringup/launch/robot_description.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/robot_description.launch.py
@@ -18,9 +18,7 @@ ARGUMENTS = [
     DeclareLaunchArgument('visualize_rays', default_value='false',
                           choices=['true', 'false'],
                           description='Enable/disable ray visualization'),
-    DeclareLaunchArgument('robot_name', default_value='create3',
-                          description='Robot name'),
-    DeclareLaunchArgument('namespace', default_value=LaunchConfiguration('robot_name'),
+    DeclareLaunchArgument('namespace', default_value='',
                           description='Robot namespace'),
 ]
 

--- a/irobot_create_common/irobot_create_common_bringup/launch/robot_description.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/robot_description.launch.py
@@ -10,7 +10,6 @@ from launch.substitutions import Command, PathJoinSubstitution
 from launch.substitutions.launch_configuration import LaunchConfiguration
 from launch_ros.actions import Node
 
-from nav2_common.launch import RewrittenYaml
 
 ARGUMENTS = [
     DeclareLaunchArgument('gazebo', default_value='classic',
@@ -26,20 +25,10 @@ ARGUMENTS = [
 
 def generate_launch_description():
     pkg_create3_description = get_package_share_directory('irobot_create_description')
-    pkg_create3_control = get_package_share_directory('irobot_create_control')
     xacro_file = PathJoinSubstitution([pkg_create3_description, 'urdf', 'create3.urdf.xacro'])
     gazebo_simulator = LaunchConfiguration('gazebo')
     visualize_rays = LaunchConfiguration('visualize_rays')
-    namespace = LaunchConfiguration('robot_name')
-
-    control_params_file = PathJoinSubstitution(
-        [pkg_create3_control, 'config', 'control.yaml'])
-
-    namespaced_control_params_file = RewrittenYaml(
-        source_file=control_params_file,
-        root_key=namespace,
-        param_rewrites={},
-    )
+    robot_name = LaunchConfiguration('robot_name')
 
     robot_state_publisher = Node(
         package='robot_state_publisher',
@@ -53,8 +42,7 @@ def generate_launch_description():
                   ['xacro', ' ', xacro_file, ' ',
                    'gazebo:=', gazebo_simulator, ' ',
                    'visualize_rays:=', visualize_rays, ' ',
-                   'namespace:=', namespace, ' ',
-                   'control_params:=', control_params_file])},
+                   'namespace:=', robot_name])},
         ],
         remappings=[
             ('/tf', 'tf'),

--- a/irobot_create_common/irobot_create_common_bringup/launch/rviz2.launch.py
+++ b/irobot_create_common/irobot_create_common_bringup/launch/rviz2.launch.py
@@ -23,6 +23,10 @@ def generate_launch_description():
         arguments=[
             '--display-config', rviz_config,
             '--splash-screen', rviz_logo,
+        ],
+        remappings=[
+            ('/tf', 'tf'),
+            ('/tf_static', 'tf_static'),
         ]
     )
 

--- a/irobot_create_common/irobot_create_common_bringup/rviz/irobot_create_view.rviz
+++ b/irobot_create_common/irobot_create_common_bringup/rviz/irobot_create_view.rviz
@@ -52,7 +52,7 @@ Visualization Manager:
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /robot_description
+        Value: robot_description
       Enabled: true
       Links:
         All Links Enabled: true
@@ -116,7 +116,7 @@ Visualization Manager:
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /standard_dock_description
+        Value: standard_dock_description
       Enabled: true
       Links:
         All Links Enabled: true
@@ -184,14 +184,14 @@ Visualization Manager:
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /initialpose
+        Value: initialpose
     - Class: rviz_default_plugins/SetGoal
       Topic:
         Depth: 5
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /goal_pose
+        Value: goal_pose
     - Class: rviz_default_plugins/PublishPoint
       Single click: true
       Topic:
@@ -199,7 +199,7 @@ Visualization Manager:
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /clicked_point
+        Value: clicked_point
   Transformation:
     Current:
       Class: rviz_default_plugins/TF

--- a/irobot_create_common/irobot_create_control/config/control.yaml
+++ b/irobot_create_common/irobot_create_control/config/control.yaml
@@ -1,77 +1,78 @@
-controller_manager:
-  ros__parameters:
-    update_rate: 1000  # Hz
+/**:  
+  controller_manager:
+    ros__parameters:
+      update_rate: 1000  # Hz
 
-    joint_state_broadcaster:
-      type: joint_state_broadcaster/JointStateBroadcaster
+      joint_state_broadcaster:
+        type: joint_state_broadcaster/JointStateBroadcaster
 
-    diffdrive_controller:
-      type: diff_drive_controller/DiffDriveController
+      diffdrive_controller:
+        type: diff_drive_controller/DiffDriveController
 
-diffdrive_controller:
-  ros__parameters:
-    use_sim_time: True
-    left_wheel_names: ["left_wheel_joint"]
-    right_wheel_names: ["right_wheel_joint"]
+  diffdrive_controller:
+    ros__parameters:
+      use_sim_time: True
+      left_wheel_names: ["left_wheel_joint"]
+      right_wheel_names: ["right_wheel_joint"]
 
-    wheel_separation: 0.233
-    wheel_radius: 0.03575
+      wheel_separation: 0.233
+      wheel_radius: 0.03575
 
-    # Multiplier applied to the wheel separation parameter.
-    # This is used to account for a difference between the robot model and a real robot.
-    wheel_separation_multiplier: 1.0
+      # Multiplier applied to the wheel separation parameter.
+      # This is used to account for a difference between the robot model and a real robot.
+      wheel_separation_multiplier: 1.0
 
-    # Multipliers applied to the wheel radius parameter.
-    # This is used to account for a difference between the robot model and a real robot.
-    left_wheel_radius_multiplier: 1.0
-    right_wheel_radius_multiplier: 1.0
+      # Multipliers applied to the wheel radius parameter.
+      # This is used to account for a difference between the robot model and a real robot.
+      left_wheel_radius_multiplier: 1.0
+      right_wheel_radius_multiplier: 1.0
 
-    publish_rate: 62.0
-    odom_frame_id: odom
-    base_frame_id: base_link
-    pose_covariance_diagonal : [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
-    twist_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
+      publish_rate: 62.0
+      odom_frame_id: odom
+      base_frame_id: base_link
+      pose_covariance_diagonal : [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
+      twist_covariance_diagonal: [0.001, 0.001, 0.001, 0.001, 0.001, 0.01]
 
-    open_loop: false
-    enable_odom_tf: true
+      open_loop: false
+      enable_odom_tf: true
 
-    cmd_vel_timeout: 0.5
-    use_stamped_vel: false
+      cmd_vel_timeout: 0.5
+      use_stamped_vel: false
 
-    # Preserve turning radius when limiting speed/acceleration/jerk
-    preserve_turning_radius: true
+      # Preserve turning radius when limiting speed/acceleration/jerk
+      preserve_turning_radius: true
 
-    # Publish limited velocity
-    publish_cmd: true
+      # Publish limited velocity
+      publish_cmd: true
 
-    # Publish wheel data
-    publish_wheel_data: true
+      # Publish wheel data
+      publish_wheel_data: true
 
-    # Velocity and acceleration limits in cartesian
-    # These limits do not factor in per wheel limits
-    # that might be exceeded when linear and angular are combined
-    # Whenever a min_* is unspecified, default to -max_*
-    linear.x.has_velocity_limits: true
-    linear.x.has_acceleration_limits: true
-    linear.x.has_jerk_limits: false
-    # This is max if system is safety_override "full"
-    # motion_control_node will bound this to 0.306 if safety enabled (as is by default)
-    linear.x.max_velocity: 0.46
-    linear.x.min_velocity: -0.46
-    linear.x.max_acceleration: 0.9
-    # Not using jerk limits yet
-    # linear.x.max_jerk: 0.0
-    # linear.x.min_jerk: 0.0
+      # Velocity and acceleration limits in cartesian
+      # These limits do not factor in per wheel limits
+      # that might be exceeded when linear and angular are combined
+      # Whenever a min_* is unspecified, default to -max_*
+      linear.x.has_velocity_limits: true
+      linear.x.has_acceleration_limits: true
+      linear.x.has_jerk_limits: false
+      # This is max if system is safety_override "full"
+      # motion_control_node will bound this to 0.306 if safety enabled (as is by default)
+      linear.x.max_velocity: 0.46
+      linear.x.min_velocity: -0.46
+      linear.x.max_acceleration: 0.9
+      # Not using jerk limits yet
+      # linear.x.max_jerk: 0.0
+      # linear.x.min_jerk: 0.0
 
-    angular.z.has_velocity_limits: true
-    angular.z.has_acceleration_limits: true
-    angular.z.has_jerk_limits: false
-    angular.z.max_velocity: 1.9
-    angular.z.min_velocity: -1.9
-    # Using 0.9 linear for each wheel, assuming one wheel accel to .9
-    # and other to -.9 with wheelbase leads to 7.725 rad/s^2
-    angular.z.max_acceleration: 7.725
-    angular.z.min_acceleration: -7.725
-    # Not using jerk limits yet
-    # angular.z.max_jerk: 0.0
-    # angular.z.min_jerk: 0.0
+      angular.z.has_velocity_limits: true
+      angular.z.has_acceleration_limits: true
+      angular.z.has_jerk_limits: false
+      angular.z.max_velocity: 1.9
+      angular.z.min_velocity: -1.9
+      # Using 0.9 linear for each wheel, assuming one wheel accel to .9
+      # and other to -.9 with wheelbase leads to 7.725 rad/s^2
+      angular.z.max_acceleration: 7.725
+      angular.z.min_acceleration: -7.725
+      # Not using jerk limits yet
+      # angular.z.max_jerk: 0.0
+      # angular.z.min_jerk: 0.0

--- a/irobot_create_common/irobot_create_control/launch/include/control.py
+++ b/irobot_create_common/irobot_create_control/launch/include/control.py
@@ -12,9 +12,7 @@ from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 
 ARGUMENTS = [
-    DeclareLaunchArgument('robot_name', default_value='create3',
-                          description='Robot name'),
-    DeclareLaunchArgument('namespace', default_value=LaunchConfiguration('robot_name'),
+    DeclareLaunchArgument('namespace', default_value='',
                           description='Robot namespace'),
 ]
 
@@ -59,7 +57,7 @@ def generate_launch_description():
         name='tf_namespaced_odom_publisher',
         arguments=['0', '0', '0',
                    '0', '0', '0',
-                   'odom', [LaunchConfiguration('namespace'), '/odom']],
+                   'odom', [namespace, '/odom']],
         remappings=[
             ('/tf', 'tf'),
             ('/tf_static', 'tf_static')
@@ -75,7 +73,7 @@ def generate_launch_description():
         name='tf_namespaced_base_link_publisher',
         arguments=['0', '0', '0',
                    '0', '0', '0',
-                   [LaunchConfiguration('namespace'), '/base_link'], 'base_link'],
+                   [namespace, '/base_link'], 'base_link'],
         remappings=[
             ('/tf', 'tf'),
             ('/tf_static', 'tf_static')

--- a/irobot_create_common/irobot_create_control/launch/include/control.py
+++ b/irobot_create_common/irobot_create_control/launch/include/control.py
@@ -13,13 +13,15 @@ from launch_ros.actions import Node
 ARGUMENTS = [
     DeclareLaunchArgument('robot_name', default_value='create3',
                           description='Robot name'),
+    DeclareLaunchArgument('namespace', default_value=LaunchConfiguration('robot_name'),
+                          description='Robot namespace'),
 ]
 
 
 def generate_launch_description():
     pkg_create3_control = get_package_share_directory('irobot_create_control')
 
-    robot_name = LaunchConfiguration('robot_name')
+    namespace = LaunchConfiguration('namespace')
 
     control_params_file = PathJoinSubstitution(
         [pkg_create3_control, 'config', 'control.yaml'])
@@ -27,7 +29,7 @@ def generate_launch_description():
     diffdrive_controller_node = Node(
         package='controller_manager',
         executable='spawner',
-        namespace=robot_name,  # Namespace is not pushed when used in EventHandler
+        namespace=namespace,  # Namespace is not pushed when used in EventHandler
         parameters=[control_params_file],
         arguments=['diffdrive_controller', '-c', 'controller_manager'],
         output='screen',
@@ -48,7 +50,7 @@ def generate_launch_description():
         )
     )
 
-    # Static transform from <robot_name>/odom to odom
+    # Static transform from <namespace>/odom to odom
     # See https://github.com/ros-controls/ros2_controllers/pull/533
     tf_namespaced_odom_publisher = Node(
         package='tf2_ros',
@@ -56,7 +58,7 @@ def generate_launch_description():
         name='tf_namespaced_odom_publisher',
         arguments=['0', '0', '0',
                    '0', '0', '0',
-                   [LaunchConfiguration('robot_name'), '/odom'], 'odom'],
+                   [LaunchConfiguration('namespace'), '/odom'], 'odom'],
         remappings=[
             ('/tf', 'tf'),
             ('/tf_static', 'tf_static')
@@ -64,14 +66,14 @@ def generate_launch_description():
         output='screen',
     )
 
-    # Static transform from <robot_name>/base_link to base_link
+    # Static transform from <namespace>/base_link to base_link
     tf_namespaced_base_link_publisher = Node(
         package='tf2_ros',
         executable='static_transform_publisher',
         name='tf_namespaced_base_link_publisher',
         arguments=['0', '0', '0',
                    '0', '0', '0',
-                   [LaunchConfiguration('robot_name'), '/base_link'], 'base_link'],
+                   [LaunchConfiguration('namespace'), '/base_link'], 'base_link'],
         remappings=[
             ('/tf', 'tf'),
             ('/tf_static', 'tf_static')

--- a/irobot_create_common/irobot_create_control/launch/include/control.py
+++ b/irobot_create_common/irobot_create_control/launch/include/control.py
@@ -27,7 +27,7 @@ def generate_launch_description():
     diffdrive_controller_node = Node(
         package='controller_manager',
         executable='spawner',
-        namespace=robot_name,  # Namespace is not pushed when used in EventHandler 
+        namespace=robot_name,  # Namespace is not pushed when used in EventHandler
         parameters=[control_params_file],
         arguments=['diffdrive_controller', '-c', 'controller_manager'],
         output='screen',

--- a/irobot_create_common/irobot_create_control/launch/include/control.py
+++ b/irobot_create_common/irobot_create_control/launch/include/control.py
@@ -5,10 +5,15 @@
 
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
-from launch.actions import RegisterEventHandler
+from launch.actions import DeclareLaunchArgument, RegisterEventHandler
 from launch.event_handlers import OnProcessExit
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
+
+ARGUMENTS = [
+    DeclareLaunchArgument('robot_name', default_value='create3',
+                          description='Robot name'),
+]
 
 
 def generate_launch_description():
@@ -24,14 +29,14 @@ def generate_launch_description():
         executable='spawner',
         namespace=robot_name,  # Namespace is not pushed when used in EventHandler 
         parameters=[control_params_file],
-        arguments=['diffdrive_controller', '-c', 'controller_manager'],
+        arguments=['diffdrive_controller', '-c', 'controller_manager', '-n', robot_name],
         output='screen',
     )
 
     joint_state_broadcaster_spawner = Node(
         package='controller_manager',
         executable='spawner',
-        arguments=['joint_state_broadcaster', '-c', 'controller_manager'],
+        arguments=['joint_state_broadcaster', '-c', 'controller_manager', '-n', robot_name],
         output='screen',
     )
 
@@ -43,7 +48,7 @@ def generate_launch_description():
         )
     )
 
-    ld = LaunchDescription()
+    ld = LaunchDescription(ARGUMENTS)
 
     ld.add_action(joint_state_broadcaster_spawner)
     ld.add_action(diffdrive_controller_callback)

--- a/irobot_create_common/irobot_create_control/launch/include/control.py
+++ b/irobot_create_common/irobot_create_control/launch/include/control.py
@@ -6,6 +6,7 @@
 from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, RegisterEventHandler
+from launch.conditions import LaunchConfigurationNotEquals
 from launch.event_handlers import OnProcessExit
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
@@ -58,12 +59,13 @@ def generate_launch_description():
         name='tf_namespaced_odom_publisher',
         arguments=['0', '0', '0',
                    '0', '0', '0',
-                   [LaunchConfiguration('namespace'), '/odom'], 'odom'],
+                   'odom', [LaunchConfiguration('namespace'), '/odom']],
         remappings=[
             ('/tf', 'tf'),
             ('/tf_static', 'tf_static')
         ],
         output='screen',
+        condition=LaunchConfigurationNotEquals('namespace', '')
     )
 
     # Static transform from <namespace>/base_link to base_link
@@ -79,6 +81,7 @@ def generate_launch_description():
             ('/tf_static', 'tf_static')
         ],
         output='screen',
+        condition=LaunchConfigurationNotEquals('namespace', '')
     )
 
     ld = LaunchDescription(ARGUMENTS)

--- a/irobot_create_common/irobot_create_control/launch/include/control.py
+++ b/irobot_create_common/irobot_create_control/launch/include/control.py
@@ -7,12 +7,14 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import RegisterEventHandler
 from launch.event_handlers import OnProcessExit
-from launch.substitutions import PathJoinSubstitution
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 
 
 def generate_launch_description():
     pkg_create3_control = get_package_share_directory('irobot_create_control')
+
+    robot_name = LaunchConfiguration('robot_name')
 
     control_params_file = PathJoinSubstitution(
         [pkg_create3_control, 'config', 'control.yaml'])
@@ -20,15 +22,16 @@ def generate_launch_description():
     diffdrive_controller_node = Node(
         package='controller_manager',
         executable='spawner',
+        namespace=robot_name,  # Namespace is not pushed when used in EventHandler 
         parameters=[control_params_file],
-        arguments=['diffdrive_controller', '-c', '/controller_manager'],
+        arguments=['diffdrive_controller', '-c', 'controller_manager'],
         output='screen',
     )
 
     joint_state_broadcaster_spawner = Node(
         package='controller_manager',
         executable='spawner',
-        arguments=['joint_state_broadcaster', '-c', '/controller_manager'],
+        arguments=['joint_state_broadcaster', '-c', 'controller_manager'],
         output='screen',
     )
 

--- a/irobot_create_common/irobot_create_description/urdf/bumper.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/bumper.urdf.xacro
@@ -63,7 +63,7 @@ functional, while the 4 remaining ones are created as dummy links. -->
       <xacro:if value="${gazebo == 'classic'}">
         <plugin name="${name}_plugin" filename="libgazebo_ros_create_bumper.so">
           <ros>
-            <namespace>/</namespace>
+            <namespace>${namespace}</namespace>
             <remapping>~/out:=_internal/bumper/event</remapping>
           </ros>
         </plugin>

--- a/irobot_create_common/irobot_create_description/urdf/bumper.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/bumper.urdf.xacro
@@ -15,7 +15,7 @@ functional, while the 4 remaining ones are created as dummy links. -->
   <link name="${link_name}"/>
 </xacro:macro>
 
-<xacro:macro name="bumper" params="name:=bumper parent_link:=base_link update_rate:=62.0 gazebo visual_mesh collision_mesh
+<xacro:macro name="bumper" params="name:=bumper namespace parent_link:=base_link update_rate:=62.0 gazebo visual_mesh collision_mesh
   *origin *inertial">
   <xacro:property name="link_name" value="${name}"/>
   <xacro:property name="joint_name" value="${name}_joint"/>
@@ -51,6 +51,14 @@ functional, while the 4 remaining ones are created as dummy links. -->
       <update_rate>${update_rate}</update_rate>
       <contact>
         <collision>${link_name}_collision</collision>
+        <xacro:if value="${gazebo == 'ignition'}">
+          <xacro:if value="${namespace == ''}">
+            <topic>/bumper_contact</topic>
+          </xacro:if>
+          <xacro:if value="${namespace != ''}">
+            <topic>${namespace}/bumper_contact</topic>
+          </xacro:if>
+        </xacro:if>
       </contact>
       <xacro:if value="${gazebo == 'classic'}">
         <plugin name="${name}_plugin" filename="libgazebo_ros_create_bumper.so">

--- a/irobot_create_common/irobot_create_description/urdf/create3.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/create3.urdf.xacro
@@ -15,7 +15,7 @@
   <xacro:arg name="gazebo"                       default="classic" />
 
   <!-- Namespace -->
-  <xacro:arg name="namespace"                    default="create3"/>
+  <xacro:arg name="namespace"                    default=""/>
 
   <!-- Mechanical properties -->
   <xacro:property name="body_z_offset"           value="${-2.5*cm2m}" />

--- a/irobot_create_common/irobot_create_description/urdf/create3.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/create3.urdf.xacro
@@ -294,7 +294,7 @@
 
     <gazebo>
       <plugin filename="libignition-gazebo-sensors-system.so" name="ignition::gazebo::systems::Sensors">
-        <render_engine>ogre2</render_engine>
+        <render_engine>ogre</render_engine>
       </plugin>
     </gazebo>
   </xacro:if>

--- a/irobot_create_common/irobot_create_description/urdf/create3.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/create3.urdf.xacro
@@ -86,6 +86,7 @@
   <!-- Bumper -->
   <xacro:bumper
       gazebo="$(arg gazebo)"
+      namespace="$(arg namespace)"
       visual_mesh="package://irobot_create_description/meshes/bumper_visual.dae"
       collision_mesh="package://irobot_create_description/meshes/bumper_collision.dae">
     <origin xyz="0 0 ${bumper_offset_z  + base_link_z_offset}"/>
@@ -293,7 +294,7 @@
 
     <gazebo>
       <plugin filename="libignition-gazebo-sensors-system.so" name="ignition::gazebo::systems::Sensors">
-        <render_engine>ogre</render_engine>
+        <render_engine>ogre2</render_engine>
       </plugin>
     </gazebo>
   </xacro:if>

--- a/irobot_create_common/irobot_create_description/urdf/create3.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/create3.urdf.xacro
@@ -99,11 +99,11 @@
   </xacro:bumper>
 
   <!-- Wheels with mechanical wheel drop -->
-  <xacro:wheel_with_wheeldrop name="left" gazebo="$(arg gazebo)">
+  <xacro:wheel_with_wheeldrop name="left" gazebo="$(arg gazebo)" namespace="$(arg namespace)">
     <origin xyz="0 ${distance_between_wheels/2} ${wheel_drop_z  + base_link_z_offset}" rpy="${-pi/2} 0 0"/>
   </xacro:wheel_with_wheeldrop>
 
-  <xacro:wheel_with_wheeldrop name="right" gazebo="$(arg gazebo)">
+  <xacro:wheel_with_wheeldrop name="right" gazebo="$(arg gazebo)" namespace="$(arg namespace)">
     <origin xyz="0 ${-distance_between_wheels/2} ${wheel_drop_z  + base_link_z_offset}" rpy="${-pi/2} 0 0"/>
   </xacro:wheel_with_wheeldrop>
 
@@ -113,16 +113,19 @@
   </xacro:caster>
 
   <!-- IMU -->
-  <xacro:imu_sensor gazebo="$(arg gazebo)">
+  <xacro:imu_sensor gazebo="$(arg gazebo)" namespace="$(arg namespace)">
     <origin xyz="0.050613 0.043673 ${0.0202 + base_link_z_offset}"/>
   </xacro:imu_sensor>
 
   <xacro:if value="${'$(arg gazebo)' == 'classic'}">
     <gazebo>
       <plugin name="gazebo_ros2_control" filename="libgazebo_ros2_control.so">
-        <parameters> $(find irobot_create_control)/config/control.yaml </parameters>
+        <parameters>$(find irobot_create_control)/config/control.yaml</parameters>
         <ros>
           <remapping>~/odom:=odom</remapping>
+          <remapping>/tf:=tf</remapping>
+          <remapping>/tf_static:=tf_static</remapping>
+          <remapping>/diagnostics:=diagnostics</remapping>
           <namespace>$(arg namespace)</namespace>
         </ros>
       </plugin>
@@ -145,7 +148,7 @@
   </xacro:if>
 
   <!-- Mouse -->
-  <xacro:optical_mouse gazebo="$(arg gazebo)">
+  <xacro:optical_mouse gazebo="$(arg gazebo)" namespace="$(arg namespace)">
     <origin xyz="0.1015 0.087 ${-0.055 + base_link_z_offset}" rpy="0 0 ${-pi/4}"/>
   </xacro:optical_mouse>
 
@@ -162,22 +165,22 @@
   <xacro:property name="cliff_back_pitch" value="${80*deg2rad}"/>
   <xacro:property name="cliff_back_yaw" value="${167.4*deg2rad}"/>
 
-  <xacro:cliff_sensor name="side_left" gazebo="$(arg gazebo)" visualize="$(arg visualize_rays)">
+  <xacro:cliff_sensor name="side_left" gazebo="$(arg gazebo)" visualize="$(arg visualize_rays)" namespace="$(arg namespace)">
     <origin xyz="${cliff_back_x} ${cliff_back_y} ${cliff_z + base_link_z_offset}"
             rpy="0 ${cliff_back_pitch} ${cliff_back_yaw}"/>
   </xacro:cliff_sensor>
 
-  <xacro:cliff_sensor name="side_right" gazebo="$(arg gazebo)" visualize="$(arg visualize_rays)">
+  <xacro:cliff_sensor name="side_right" gazebo="$(arg gazebo)" visualize="$(arg visualize_rays)" namespace="$(arg namespace)">
     <origin xyz="${cliff_back_x} ${- cliff_back_y} ${cliff_z + base_link_z_offset}"
             rpy="0 ${cliff_back_pitch} ${- cliff_back_yaw}"/>
   </xacro:cliff_sensor>
 
-  <xacro:cliff_sensor name="front_left" gazebo="$(arg gazebo)" visualize="$(arg visualize_rays)">
+  <xacro:cliff_sensor name="front_left" gazebo="$(arg gazebo)" visualize="$(arg visualize_rays)" namespace="$(arg namespace)">
     <origin xyz="${cliff_center_x} ${cliff_center_y} ${cliff_z + base_link_z_offset}"
             rpy="0 ${cliff_center_pitch} ${cliff_center_yaw}"/>
   </xacro:cliff_sensor>
 
-  <xacro:cliff_sensor name="front_right" gazebo="$(arg gazebo)" visualize="$(arg visualize_rays)">
+  <xacro:cliff_sensor name="front_right" gazebo="$(arg gazebo)" visualize="$(arg visualize_rays)" namespace="$(arg namespace)">
     <origin xyz="${cliff_center_x} ${- cliff_center_y} ${cliff_z + base_link_z_offset}"
             rpy="0 ${cliff_center_pitch} ${- cliff_center_yaw}"/>
   </xacro:cliff_sensor>
@@ -199,25 +202,25 @@
             left                                    front_right
   side_left                                                   right
   -->
-  <xacro:ir_intensity name="front_center_left" gazebo="$(arg gazebo)">
+  <xacro:ir_intensity name="front_center_left" gazebo="$(arg gazebo)" namespace="$(arg namespace)">
     <origin xyz="0.1540 0 ${ir_intensity_z_pos + base_link_z_offset}"/>
   </xacro:ir_intensity>
-  <xacro:ir_intensity name="front_center_right" gazebo="$(arg gazebo)">
+  <xacro:ir_intensity name="front_center_right" gazebo="$(arg gazebo)" namespace="$(arg namespace)">
     <origin xyz="0.1396 -0.0651 ${ir_intensity_z_pos + base_link_z_offset}" rpy="0 0 -0.436"/>
   </xacro:ir_intensity>
-  <xacro:ir_intensity name="front_left" gazebo="$(arg gazebo)">
+  <xacro:ir_intensity name="front_left" gazebo="$(arg gazebo)" namespace="$(arg namespace)">
     <origin xyz="0.1396 0.0651 ${ir_intensity_z_pos + base_link_z_offset}" rpy="0 0 0.436"/>
   </xacro:ir_intensity>
-  <xacro:ir_intensity name="front_right" gazebo="$(arg gazebo)">
+  <xacro:ir_intensity name="front_right" gazebo="$(arg gazebo)" namespace="$(arg namespace)">
     <origin xyz="0.0990 -0.1180 ${ir_intensity_z_pos + base_link_z_offset}" rpy="0 0 -0.873"/>
   </xacro:ir_intensity>
-  <xacro:ir_intensity name="left" gazebo="$(arg gazebo)">
+  <xacro:ir_intensity name="left" gazebo="$(arg gazebo)" namespace="$(arg namespace)">
     <origin xyz="0.0990 0.1180 ${ir_intensity_z_pos + base_link_z_offset}" rpy="0 0 0.873"/>
   </xacro:ir_intensity>
-  <xacro:ir_intensity name="right" gazebo="$(arg gazebo)">
+  <xacro:ir_intensity name="right" gazebo="$(arg gazebo)" namespace="$(arg namespace)">
     <origin xyz="0.0399 -0.1488 ${ir_intensity_z_pos + base_link_z_offset}" rpy="0 0 -1.309"/>
   </xacro:ir_intensity>
-  <xacro:ir_intensity name="side_left" gazebo="$(arg gazebo)">
+  <xacro:ir_intensity name="side_left" gazebo="$(arg gazebo)" namespace="$(arg namespace)">
     <origin xyz="0.0399 0.1488 ${ir_intensity_z_pos + base_link_z_offset}" rpy="0 0 1.309"/>
   </xacro:ir_intensity>
 
@@ -238,7 +241,8 @@
   <!-- Omni IR receiver (sensor 0) parameters and Front-facing IR receiver (sensor 1) parameters -->
   <xacro:property name="ir_omni_fov_rad" value="${220.0*deg2rad}"/>
   <xacro:property name="ir_front_facing_fov_rad" value="${pi/2}"/>
-  <xacro:ir_opcode_receivers gazebo="$(arg gazebo)" robot_model_name="${robot_model_name}" dock_model_name="${dock_model_name}"
+  <xacro:ir_opcode_receivers gazebo="$(arg gazebo)" namespace="$(arg namespace)"
+    robot_model_name="${robot_model_name}" dock_model_name="${dock_model_name}"
     emitter_link_name="${emitter_link_name}" sensor_0_range="0.01" sensor_0_fov="${ir_omni_fov_rad}"
     sensor_1_range="0.5" sensor_1_fov="${ir_front_facing_fov_rad}" >
     <origin xyz="0.153 0 ${0.035 + base_link_z_offset}"/>
@@ -250,7 +254,7 @@
     <gazebo>
       <plugin name="gazebo_ros_p3d_robot" filename="libgazebo_ros_p3d.so">
         <ros>
-          <namespace>/</namespace>
+          <namespace>$(arg namespace)</namespace>
           <remapping>odom:=sim_ground_truth_pose</remapping>
         </ros>
         <body_name>base_link</body_name>
@@ -266,7 +270,7 @@
     <gazebo>
       <plugin name="dock_status_publisher" filename="libgazebo_ros_create_docking_status.so">
         <ros>
-          <namespace>/</namespace>
+          <namespace>$(arg namespace)</namespace>
           <remapping>~/out:=dock_status</remapping>
         </ros>
         <update_rate>1.0</update_rate>

--- a/irobot_create_common/irobot_create_description/urdf/create3.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/create3.urdf.xacro
@@ -14,6 +14,12 @@
   <!-- Gazebo version -->
   <xacro:arg name="gazebo"                       default="classic" />
 
+  <!-- Namespace -->
+  <xacro:arg name="namespace"                    default=""/>
+
+  <!-- Control -->
+  <xacro:arg name="control_params"               default="$(find irobot_create_control)/config/control.yaml"/>
+
   <!-- Mechanical properties -->
   <xacro:property name="body_z_offset"           value="${-2.5*cm2m}" />
   <xacro:property name="body_collision_z_offset" value="${1*cm2m}" />
@@ -119,6 +125,7 @@
         <parameters> $(find irobot_create_control)/config/control.yaml </parameters>
         <ros>
           <remapping>~/odom:=odom</remapping>
+          <namespace>$(arg namespace)</namespace>
         </ros>
       </plugin>
     </gazebo>
@@ -127,9 +134,13 @@
   <xacro:if value="${'$(arg gazebo)' == 'ignition'}">
     <gazebo>
       <plugin filename="libign_ros2_control-system.so" name="ign_ros2_control::IgnitionROS2ControlPlugin">
-        <parameters> $(find irobot_create_control)/config/control.yaml </parameters>
+        <parameters>$(find irobot_create_control)/config/control.yaml</parameters>
         <ros>
           <remapping>~/odom:=odom</remapping>
+          <remapping>/tf:=tf</remapping>
+          <remapping>/tf_static:=tf_static</remapping>
+          <remapping>/diagnostics:=diagnostics</remapping>
+          <namespace>$(arg namespace)</namespace>
         </ros>
       </plugin>
     </gazebo>
@@ -289,5 +300,4 @@
       </plugin>
     </gazebo>
   </xacro:if>
-
 </robot>

--- a/irobot_create_common/irobot_create_description/urdf/create3.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/create3.urdf.xacro
@@ -15,10 +15,7 @@
   <xacro:arg name="gazebo"                       default="classic" />
 
   <!-- Namespace -->
-  <xacro:arg name="namespace"                    default=""/>
-
-  <!-- Control -->
-  <xacro:arg name="control_params"               default="$(find irobot_create_control)/config/control.yaml"/>
+  <xacro:arg name="namespace"                    default="create3"/>
 
   <!-- Mechanical properties -->
   <xacro:property name="body_z_offset"           value="${-2.5*cm2m}" />

--- a/irobot_create_common/irobot_create_description/urdf/dock/standard_dock.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/dock/standard_dock.urdf.xacro
@@ -5,6 +5,7 @@
 
   <!-- Gazebo version -->
   <xacro:arg name="gazebo"         default="classic" />
+  <xacro:arg name="namespace"      default="" />
 
   <xacro:property name="z_offset"  value="${4.6*mm2m}"/>
   <xacro:property name="link_name" value="std_dock_link"/>
@@ -88,7 +89,7 @@
       <!-- Ground truth pose-->
       <plugin name="gazebo_ros_p3d_dock" filename="libgazebo_ros_p3d.so">
         <ros>
-          <namespace>/</namespace>
+          <namespace>$(arg namespace)</namespace>
           <remapping>odom:=sim_ground_truth_dock_pose</remapping>
         </ros>
         <body_name>${link_name}</body_name>

--- a/irobot_create_common/irobot_create_description/urdf/sensors/cliff_sensor.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/sensors/cliff_sensor.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-<xacro:macro name="cliff_sensor" params="name gazebo parent:=base_link
+<xacro:macro name="cliff_sensor" params="name gazebo namespace parent:=base_link
                                          visualize:=false *origin">
   <!-- Sensor settings -->
   <xacro:property name="update_rate"         value="62"/>
@@ -31,7 +31,7 @@
                       r_min="${min_range}" r_max="${max_range}" r_res="1.0">
       <plugin name="${sensor_name}" filename="libgazebo_ros_create_cliff_sensor.so">
         <ros>
-          <namespace>/</namespace>
+          <namespace>${namespace}</namespace>
           <remapping>~/out:=_internal/${sensor_name}/event</remapping>
         </ros>
         <detection_threshold>${detection_threshold}</detection_threshold>

--- a/irobot_create_common/irobot_create_description/urdf/sensors/imu.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/sensors/imu.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-<xacro:macro name="imu_sensor" params="name:=imu gazebo parent:=base_link update_rate:=62 *origin">
+<xacro:macro name="imu_sensor" params="name:=imu gazebo namespace parent:=base_link update_rate:=62 *origin">
 
   <joint name="${name}_joint" type="fixed">
     <xacro:insert_block name="origin"/>
@@ -62,7 +62,7 @@
       <xacro:if value="${gazebo == 'classic'}">
         <plugin name="${name}_plugin" filename="libgazebo_ros_create_imu.so">
           <ros>
-            <namespace>/</namespace>
+            <namespace>${namespace}</namespace>
             <remapping>~/out:=imu</remapping>
           </ros>
         </plugin>

--- a/irobot_create_common/irobot_create_description/urdf/sensors/ir_intensity.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/sensors/ir_intensity.urdf.xacro
@@ -3,7 +3,7 @@
   <xacro:include filename="$(find irobot_create_description)/urdf/common_properties.urdf.xacro"/>
 
   <xacro:macro name="ir_intensity"
-               params="name gazebo parent:=base_link
+               params="name gazebo namespace parent:=base_link
                        update_rate:=62.0 fov:=${10*deg2rad}
                        min_range:=${25*mm2m} max_range:=${200*mm2m}
                        visualize:=false *origin" >
@@ -32,7 +32,7 @@
                       r_min="${min_range}" r_max="${max_range}" r_res="1.0">
           <plugin filename="libgazebo_ros_create_ir_intensity_sensor.so" name="${link_name}">
             <ros>
-              <namespace>/</namespace>
+              <namespace>${namespace}</namespace>
               <remapping>~/out:=_internal/${link_name}</remapping>
             </ros>
           </plugin>

--- a/irobot_create_common/irobot_create_description/urdf/sensors/ir_opcode_receivers.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/sensors/ir_opcode_receivers.urdf.xacro
@@ -4,6 +4,7 @@
 
   <xacro:macro name="ir_opcode_receivers" params="name:=ir_omni
                                                   gazebo
+                                                  namespace
                                                   robot_model_name
                                                   dock_model_name
                                                   emitter_link_name
@@ -59,7 +60,7 @@
       <gazebo>
         <plugin name="${name}_plugin" filename="libgazebo_ros_create_ir_opcode.so">
           <ros>
-            <namespace>/</namespace>
+            <namespace>${namespace}</namespace>
             <remapping>~/out:=ir_opcode</remapping>
           </ros>
           <update_rate>${update_rate}</update_rate>

--- a/irobot_create_common/irobot_create_description/urdf/sensors/ir_opcode_receivers.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/sensors/ir_opcode_receivers.urdf.xacro
@@ -14,7 +14,7 @@
                                                   sensor_1_range
                                                   samples:=50
                                                   min_range:=0.015
-                                                  update_rate:=31
+                                                  update_rate:=62
                                                   visualize:=false
                                                   *origin" >
 

--- a/irobot_create_common/irobot_create_description/urdf/sensors/optical_mouse.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/sensors/optical_mouse.urdf.xacro
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-  <xacro:macro name="optical_mouse" params="name:=mouse gazebo parent_link:=base_link update_rate:=62 *origin" >
+  <xacro:macro name="optical_mouse" params="name:=mouse gazebo namespace parent_link:=base_link update_rate:=62 *origin" >
 
     <joint name="${name}_joint" type="fixed">
       <xacro:insert_block name="origin"/>
@@ -17,7 +17,7 @@
       <gazebo>
         <plugin name="${name}_plugin" filename="libgazebo_ros_create_optical_mouse.so">
             <ros>
-              <namespace>/</namespace>
+              <namespace>${namespace}</namespace>
               <remapping>~/out:=${name}</remapping>
             </ros>
           <update_rate>${update_rate}</update_rate>

--- a/irobot_create_common/irobot_create_description/urdf/wheel_drop.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/wheel_drop.urdf.xacro
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
-<xacro:macro name="wheel_drop" params="name gazebo parent_link *origin" >
+<xacro:macro name="wheel_drop" params="name gazebo parent_link namespace *origin" >
   <xacro:include filename="$(find irobot_create_description)/urdf/common_properties.urdf.xacro"/>
 
   <xacro:property name="detection_threshold" value="${3*cm2m}"/>
@@ -52,7 +52,7 @@
     <gazebo>
       <plugin name="${wd_link_name}_plugin" filename="libgazebo_ros_create_wheel_drop.so">
         <ros>
-          <namespace>/</namespace>
+          <namespace>$(arg namespace)</namespace>
           <remapping>~/out:=_internal/wheel_drop/${name}_wheel/event</remapping>
         </ros>
         <update_rate>${update_rate}</update_rate>

--- a/irobot_create_common/irobot_create_description/urdf/wheel_with_wheeldrop.urdf.xacro
+++ b/irobot_create_common/irobot_create_description/urdf/wheel_with_wheeldrop.urdf.xacro
@@ -1,12 +1,12 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
-<xacro:macro name="wheel_with_wheeldrop" params="name gazebo parent_link:=base_link *origin">
+<xacro:macro name="wheel_with_wheeldrop" params="name gazebo namespace parent_link:=base_link *origin">
   <xacro:include filename="$(find irobot_create_description)/urdf/wheel.urdf.xacro" />
   <xacro:include filename="$(find irobot_create_description)/urdf/wheel_drop.urdf.xacro" />
 
   <!-- Wheel Drop definition -->
-  <xacro:wheel_drop name="${name}" gazebo="${gazebo}" parent_link="${parent_link}">
+  <xacro:wheel_drop name="${name}" gazebo="${gazebo}" parent_link="${parent_link}" namespace="${namespace}">
     <xacro:insert_block name="origin"/>
   </xacro:wheel_drop>
 

--- a/irobot_create_common/irobot_create_nodes/src/hazards_vector_publisher.cpp
+++ b/irobot_create_common/irobot_create_nodes/src/hazards_vector_publisher.cpp
@@ -16,7 +16,7 @@ HazardsVectorPublisher::HazardsVectorPublisher(const rclcpp::NodeOptions & optio
 {
   // Topic parameter to publish hazards vector to
   publisher_topic_ =
-    this->declare_parameter("publisher_topic", "/hazard_detection");
+    this->declare_parameter("publisher_topic", "hazard_detection");
 
   // Subscription topics parameter
   subscription_topics_ =

--- a/irobot_create_common/irobot_create_nodes/src/ir_intensity_vector_publisher.cpp
+++ b/irobot_create_common/irobot_create_nodes/src/ir_intensity_vector_publisher.cpp
@@ -16,7 +16,7 @@ IrIntensityVectorPublisher::IrIntensityVectorPublisher(const rclcpp::NodeOptions
 {
   // Topic parameter to publish IR intensity vector to
   publisher_topic_ =
-    this->declare_parameter("publisher_topic", "/ir_intensity");
+    this->declare_parameter("publisher_topic", "ir_intensity");
 
   // Subscription topics parameter
   subscription_topics_ =

--- a/irobot_create_common/irobot_create_nodes/src/kidnap_estimator_publisher.cpp
+++ b/irobot_create_common/irobot_create_nodes/src/kidnap_estimator_publisher.cpp
@@ -16,11 +16,11 @@ KidnapEstimator::KidnapEstimator(const rclcpp::NodeOptions & options)
 {
   // Topic parameter to publish kidnap status to
   kidnap_status_publisher_topic_ =
-    this->declare_parameter("kidnap_status_topic", "/kidnap_status");
+    this->declare_parameter("kidnap_status_topic", "kidnap_status");
 
   // Subscriber topics
   hazard_subscription_topic_ =
-    this->declare_parameter("hazard_topic", "/hazard_detection");
+    this->declare_parameter("hazard_topic", "hazard_detection");
 
   // Define kidnap status publisher
   kidnap_status_publisher_ = create_publisher<irobot_create_msgs::msg::KidnapStatus>(

--- a/irobot_create_common/irobot_create_nodes/src/mock_publisher.cpp
+++ b/irobot_create_common/irobot_create_nodes/src/mock_publisher.cpp
@@ -19,7 +19,7 @@ MockPublisher::MockPublisher(const rclcpp::NodeOptions & options)
 {
   // Topic parameter to publish slip status to
   slip_status_publisher_topic_ =
-    this->declare_parameter("slip_status_topic", "/slip_status");
+    this->declare_parameter("slip_status_topic", "slip_status");
 
   // Publish rate parameters in Hz
   const double slip_status_publish_rate =

--- a/irobot_create_common/irobot_create_nodes/src/robot_state.cpp
+++ b/irobot_create_common/irobot_create_nodes/src/robot_state.cpp
@@ -22,16 +22,16 @@ RobotState::RobotState(const rclcpp::NodeOptions & options)
 
   // Topic parameter to publish battery state to
   battery_state_publisher_topic_ =
-    this->declare_parameter("battery_state_topic", "/battery_state");
+    this->declare_parameter("battery_state_topic", "battery_state");
   // Topic parameter to publish stop status to
   stop_status_publisher_topic_ =
-    this->declare_parameter("stop_status_topic", "/stop_status");
+    this->declare_parameter("stop_status_topic", "stop_status");
 
   // Subscriber topics
   dock_subscription_topic_ =
-    this->declare_parameter("dock_topic", "/dock_status");
+    this->declare_parameter("dock_topic", "dock_status");
   wheel_vels_subscription_topic_ =
-    this->declare_parameter("wheel_vels_topic", "/odom");
+    this->declare_parameter("wheel_vels_topic", "odom");
 
   // Publish rate parameters in Hz
   const double battery_state_publish_rate =

--- a/irobot_create_common/irobot_create_nodes/src/ui_mgr.cpp
+++ b/irobot_create_common/irobot_create_nodes/src/ui_mgr.cpp
@@ -28,13 +28,13 @@ UIMgr::UIMgr(const rclcpp::NodeOptions & options)
 
   // Topic parameter to publish buttons to
   buttons_publisher_topic_ =
-    this->declare_parameter("button_topic", "/interface_buttons");
+    this->declare_parameter("button_topic", "interface_buttons");
 
   // Subscriber topics
   lightring_subscription_topic_ =
-    this->declare_parameter("lightring_topic", "/cmd_lightring");
+    this->declare_parameter("lightring_topic", "cmd_lightring");
   audio_subscription_topic_ =
-    this->declare_parameter("audio_topic", "/cmd_audio");
+    this->declare_parameter("audio_topic", "cmd_audio");
 
   // Publish rate parameters in Hz
   const double buttons_publish_rate =

--- a/irobot_create_common/irobot_create_nodes/src/wheels_publisher.cpp
+++ b/irobot_create_common/irobot_create_nodes/src/wheels_publisher.cpp
@@ -16,11 +16,11 @@ WheelsPublisher::WheelsPublisher(const rclcpp::NodeOptions & options)
 {
   // Topic parameter to publish angular velocity to
   const std::string velocity_topic =
-    this->declare_parameter("velocity_topic", "/wheel_vels");
+    this->declare_parameter("velocity_topic", "wheel_vels");
 
   // Topic parameter to publish wheel ticks to
   const std::string ticks_topic =
-    this->declare_parameter("ticks_topic", "/wheel_ticks");
+    this->declare_parameter("ticks_topic", "wheel_ticks");
 
   // Publish rate parameter in Hz
   const double publish_rate =

--- a/irobot_create_gazebo/irobot_create_gazebo_bringup/launch/create3_gazebo.launch.py
+++ b/irobot_create_gazebo/irobot_create_gazebo_bringup/launch/create3_gazebo.launch.py
@@ -4,35 +4,12 @@
 #
 # Launch Create(R) 3 in Gazebo and optionally also in RViz.
 
-import os
-
-from pathlib import Path
-
 from ament_index_python.packages import get_package_share_directory
-from launch import LaunchContext, LaunchDescription, SomeSubstitutionsType, Substitution
-from launch.actions import DeclareLaunchArgument, ExecuteProcess
-from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable
-from launch.conditions import IfCondition
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
 from launch.launch_description_sources import PythonLaunchDescriptionSource
-from launch.substitutions import EnvironmentVariable, LaunchConfiguration, PathJoinSubstitution
-from launch_ros.actions import Node
-
-
-class OffsetParser(Substitution):
-    def __init__(
-            self,
-            number: SomeSubstitutionsType,
-            offset: float,
-    ) -> None:
-        self.__number = number
-        self.__offset = offset
-
-    def perform(
-            self,
-            context: LaunchContext = None,
-    ) -> str:
-        number = float(self.__number.perform(context))
-        return f'{number + self.__offset}'
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 
 
 ARGUMENTS = [
@@ -47,6 +24,8 @@ ARGUMENTS = [
                           description='Spawn the standard dock model.'),
     DeclareLaunchArgument('world_path', default_value='',
                           description='Set world path, by default is empty.world'),
+    DeclareLaunchArgument('namespace', default_value='',
+                          description='Robot namespace'),
 ]
 
 for pose_element in ['x', 'y', 'z', 'yaw']:
@@ -54,137 +33,38 @@ for pose_element in ['x', 'y', 'z', 'yaw']:
                      description=f'{pose_element} component of the robot pose.'))
 
 
-# Rviz requires US locale to correctly display the wheels
-os.environ['LC_NUMERIC'] = 'en_US.UTF-8'
-
-
 def generate_launch_description():
     # Directories
-    pkg_create3_common_bringup = get_package_share_directory('irobot_create_common_bringup')
     pkg_create3_gazebo_bringup = get_package_share_directory('irobot_create_gazebo_bringup')
-    pkg_irobot_create_description = get_package_share_directory('irobot_create_description')
-
-    # Set ignition resource path
-    gz_resource_path = SetEnvironmentVariable(name='GAZEBO_MODEL_PATH', value=[
-                                                EnvironmentVariable('GAZEBO_MODEL_PATH',
-                                                                    default_value=''),
-                                                '/usr/share/gazebo-11/models/:',
-                                                str(Path(pkg_irobot_create_description).
-                                                    parent.resolve())])
-
-    # Set GAZEBO_MODEL_URI to empty string to prevent Gazebo from downloading models
-    gz_model_uri = SetEnvironmentVariable(name='GAZEBO_MODEL_URI', value=[''])
 
     # Paths
-    create3_nodes_launch_file = PathJoinSubstitution(
-        [pkg_create3_common_bringup, 'launch', 'create3_nodes.launch.py'])
-    dock_description_launch_file = PathJoinSubstitution(
-        [pkg_create3_common_bringup, 'launch', 'dock_description.launch.py'])
-    robot_description_launch_file = PathJoinSubstitution(
-        [pkg_create3_common_bringup, 'launch', 'robot_description.launch.py'])
-    rviz2_launch_file = PathJoinSubstitution(
-        [pkg_create3_common_bringup, 'launch', 'rviz2.launch.py'])
+    gazebo_launch = PathJoinSubstitution(
+        [pkg_create3_gazebo_bringup, 'launch', 'gazebo.launch.py'])
+    robot_spawn_launch = PathJoinSubstitution(
+        [pkg_create3_gazebo_bringup, 'launch', 'create3_spawn.launch.py'])
 
-    gazebo_params_yaml_file = os.path.join(
-        pkg_create3_gazebo_bringup, 'config', 'gazebo_params.yaml')
-
-    # Launch configurations
-    x, y, z = LaunchConfiguration('x'), LaunchConfiguration('y'), LaunchConfiguration('z')
-    yaw = LaunchConfiguration('yaw')
-    world_path = LaunchConfiguration('world_path')
-    spawn_dock = LaunchConfiguration('spawn_dock')
-    use_gazebo_gui = LaunchConfiguration('use_gazebo_gui')
-    use_rviz = LaunchConfiguration('use_rviz')
-
-    # Gazebo server
-    gzserver = ExecuteProcess(
-        cmd=['gzserver',
-             '-s', 'libgazebo_ros_init.so',
-             '-s', 'libgazebo_ros_factory.so',
-             world_path,
-             'extra-gazebo-args', '--ros-args', '--params-file', gazebo_params_yaml_file],
-        output='screen',
+    gazebo = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([gazebo_launch]),
+        launch_arguments=[
+            ('world_path', LaunchConfiguration('world_path')),
+            ('use_gazebo_gui', LaunchConfiguration('use_gazebo_gui'))
+        ]
     )
 
-    # Gazebo client
-    gzclient = ExecuteProcess(
-        cmd=['gzclient'],
-        output='screen',
-        condition=IfCondition(use_gazebo_gui),
-    )
-
-    # Dock model and description
-    # The robot starts docked. So we spawn the dock at the robot position.
-    # We need to include an offset on the x and yaw to correctly "plug" the robot.
-    x_dock = OffsetParser(x, 0.157)
-    yaw_dock = OffsetParser(yaw, 3.1416)
-    dock_description = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([dock_description_launch_file]),
-        condition=IfCondition(spawn_dock),
-        # The robot starts docked
-        launch_arguments={'x': x_dock, 'y': y, 'z': z, 'yaw': yaw_dock}.items(),
-    )
-    spawn_dock = Node(
-        package='gazebo_ros',
-        executable='spawn_entity.py',
-        name='spawn_standard_dock',
-        arguments=['-entity',
-                   'standard_dock',
-                   '-topic',
-                   'standard_dock_description',
-                   '-x', x_dock,
-                   '-y', y,
-                   '-z', z,
-                   '-Y', yaw_dock],
-        output='screen',
-        condition=IfCondition(spawn_dock),
-    )
-
-    # Create 3 robot model and description
-    robot_description = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([robot_description_launch_file])
-    )
-    spawn_robot = Node(
-        package='gazebo_ros',
-        executable='spawn_entity.py',
-        name='spawn_create3',
-        arguments=['-entity',
-                   'create3',
-                   '-topic',
-                   'robot_description',
-                   '-x', x,
-                   '-y', y,
-                   '-z', z,
-                   '-Y', yaw],
-        output='screen',
-    )
-
-    # Create 3 nodes
-    create3_nodes = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([create3_nodes_launch_file])
-    )
-
-    # RVIZ2
-    rviz2 = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([rviz2_launch_file]),
-        condition=IfCondition(use_rviz),
-    )
+    robot_spawn = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([robot_spawn_launch]),
+        launch_arguments=[
+            ('namespace', LaunchConfiguration('namespace')),
+            ('use_rviz', LaunchConfiguration('use_rviz')),
+            ('x', LaunchConfiguration('x')),
+            ('y', LaunchConfiguration('y')),
+            ('z', LaunchConfiguration('z')),
+            ('yaw', LaunchConfiguration('yaw'))])
 
     # Define LaunchDescription variable
     ld = LaunchDescription(ARGUMENTS)
-    # Gazebo processes
-    ld.add_action(gz_resource_path)
-    ld.add_action(gz_model_uri)
-    ld.add_action(gzserver)
-    ld.add_action(gzclient)
-    # Include robot description
-    ld.add_action(robot_description)
-    ld.add_action(spawn_robot)
-    ld.add_action(spawn_dock)
-    ld.add_action(dock_description)
-    # Include Create 3 nodes
-    ld.add_action(create3_nodes)
-    # Rviz
-    ld.add_action(rviz2)
-
+    # Gazebo
+    ld.add_action(gazebo)
+    # Robot spawn
+    ld.add_action(robot_spawn)
     return ld

--- a/irobot_create_gazebo/irobot_create_gazebo_bringup/launch/create3_spawn.launch.py
+++ b/irobot_create_gazebo/irobot_create_gazebo_bringup/launch/create3_spawn.launch.py
@@ -6,10 +6,11 @@
 
 import os
 
+from ament_index_python.packages import get_package_share_directory
+
 from irobot_create_common_bringup.namespace import GetNamespacedName
 from irobot_create_common_bringup.offset import OffsetParser, RotationalOffsetX, RotationalOffsetY
 
-from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, GroupAction
 from launch.actions import IncludeLaunchDescription

--- a/irobot_create_gazebo/irobot_create_gazebo_bringup/launch/create3_spawn.launch.py
+++ b/irobot_create_gazebo/irobot_create_gazebo_bringup/launch/create3_spawn.launch.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# Copyright 2021 iRobot Corporation. All Rights Reserved.
+# @author Rodrigo Jose Causarano Nunez (rcausaran@irobot.com)
+#
+# Launch Create(R) 3 in Gazebo and optionally also in RViz.
+
+import os
+
+from irobot_create_common_bringup.namespace import GetNamespacedName
+from irobot_create_common_bringup.offset import OffsetParser, RotationalOffsetX, RotationalOffsetY
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, GroupAction
+from launch.actions import IncludeLaunchDescription
+from launch.conditions import IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node, PushRosNamespace
+
+
+ARGUMENTS = [
+    DeclareLaunchArgument('use_rviz', default_value='true',
+                          choices=['true', 'false'],
+                          description='Start rviz.'),
+    DeclareLaunchArgument('spawn_dock', default_value='true',
+                          choices=['true', 'false'],
+                          description='Spawn the standard dock model.'),
+    DeclareLaunchArgument('namespace', default_value='',
+                          description='Robot namespace'),
+]
+
+for pose_element in ['x', 'y', 'z', 'yaw']:
+    ARGUMENTS.append(DeclareLaunchArgument(pose_element, default_value='0.0',
+                     description=f'{pose_element} component of the robot pose.'))
+
+
+# Rviz requires US locale to correctly display the wheels
+os.environ['LC_NUMERIC'] = 'en_US.UTF-8'
+
+
+def generate_launch_description():
+    # Directories
+    pkg_create3_common_bringup = get_package_share_directory('irobot_create_common_bringup')
+
+    # Paths
+    create3_nodes_launch_file = PathJoinSubstitution(
+        [pkg_create3_common_bringup, 'launch', 'create3_nodes.launch.py'])
+    dock_description_launch_file = PathJoinSubstitution(
+        [pkg_create3_common_bringup, 'launch', 'dock_description.launch.py'])
+    robot_description_launch_file = PathJoinSubstitution(
+        [pkg_create3_common_bringup, 'launch', 'robot_description.launch.py'])
+    rviz2_launch_file = PathJoinSubstitution(
+        [pkg_create3_common_bringup, 'launch', 'rviz2.launch.py'])
+
+    # Launch configurations
+    namespace = LaunchConfiguration('namespace')
+    x, y, z = LaunchConfiguration('x'), LaunchConfiguration('y'), LaunchConfiguration('z')
+    yaw = LaunchConfiguration('yaw')
+    spawn_dock = LaunchConfiguration('spawn_dock')
+    use_rviz = LaunchConfiguration('use_rviz')
+
+    robot_name = GetNamespacedName(namespace, 'create3')
+    dock_name = GetNamespacedName(namespace, 'standard_dock')
+
+    # Calculate dock offset due to yaw rotation
+    dock_offset_x = RotationalOffsetX(0.157, yaw)
+    dock_offset_y = RotationalOffsetY(0.157, yaw)
+    # Spawn dock at robot position + rotational offset
+    x_dock = OffsetParser(x, dock_offset_x)
+    y_dock = OffsetParser(y, dock_offset_y)
+    # Rotate dock towards robot
+    yaw_dock = OffsetParser(yaw, 3.1416)
+
+    spawn_robot_group_action = GroupAction([
+        PushRosNamespace(namespace),
+
+        # Dock description
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([dock_description_launch_file]),
+            launch_arguments={'gazebo': 'classic'}.items(),
+            condition=IfCondition(spawn_dock),
+        ),
+
+        # Dock spawn
+        Node(
+            package='gazebo_ros',
+            executable='spawn_entity.py',
+            name='spawn_standard_dock',
+            arguments=['-entity',
+                       dock_name,
+                       '-topic',
+                       'standard_dock_description',
+                       '-x', x_dock,
+                       '-y', y_dock,
+                       '-z', z,
+                       '-Y', yaw_dock],
+            output='screen',
+            condition=IfCondition(spawn_dock),
+        ),
+
+        # Create 3 robot model and description
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([robot_description_launch_file]),
+            launch_arguments={'gazebo': 'classic'}.items(),
+        ),
+
+        # Create 3 spawn
+        Node(
+            package='gazebo_ros',
+            executable='spawn_entity.py',
+            name='spawn_create3',
+            arguments=['-entity',
+                       robot_name,
+                       '-topic',
+                       'robot_description',
+                       '-x', x,
+                       '-y', y,
+                       '-z', z,
+                       '-Y', yaw],
+            output='screen',
+        ),
+
+        # Create 3 nodes
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([create3_nodes_launch_file]),
+            launch_arguments=[
+                ('namespace', namespace)
+            ]
+        ),
+
+        # RVIZ2
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([rviz2_launch_file]),
+            condition=IfCondition(use_rviz),
+        ),
+    ])
+
+    # Define LaunchDescription variable
+    ld = LaunchDescription(ARGUMENTS)
+    ld.add_action(spawn_robot_group_action)
+    return ld

--- a/irobot_create_gazebo/irobot_create_gazebo_bringup/launch/gazebo.launch.py
+++ b/irobot_create_gazebo/irobot_create_gazebo_bringup/launch/gazebo.launch.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# Copyright 2021 iRobot Corporation. All Rights Reserved.
+# @author Rodrigo Jose Causarano Nunez (rcausaran@irobot.com)
+#
+# Launch Create(R) 3 in Gazebo and optionally also in RViz.
+
+import os
+
+from pathlib import Path
+
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess
+from launch.actions import SetEnvironmentVariable
+from launch.conditions import IfCondition
+from launch.substitutions import EnvironmentVariable, LaunchConfiguration
+
+
+ARGUMENTS = [
+    DeclareLaunchArgument('use_rviz', default_value='true',
+                          choices=['true', 'false'],
+                          description='Start rviz.'),
+    DeclareLaunchArgument('use_gazebo_gui', default_value='true',
+                          choices=['true', 'false'],
+                          description='Set "false" to run gazebo headless.'),
+    DeclareLaunchArgument('world_path', default_value='',
+                          description='Set world path, by default is empty.world'),
+]
+
+
+# Rviz requires US locale to correctly display the wheels
+os.environ['LC_NUMERIC'] = 'en_US.UTF-8'
+
+
+def generate_launch_description():
+    # Directories
+    pkg_create3_gazebo_bringup = get_package_share_directory('irobot_create_gazebo_bringup')
+    pkg_irobot_create_description = get_package_share_directory('irobot_create_description')
+
+    # Set ignition resource path
+    gz_resource_path = SetEnvironmentVariable(name='GAZEBO_MODEL_PATH', value=[
+                                                EnvironmentVariable('GAZEBO_MODEL_PATH',
+                                                                    default_value=''),
+                                                '/usr/share/gazebo-11/models/:',
+                                                str(Path(pkg_irobot_create_description).
+                                                    parent.resolve())])
+
+    # Set GAZEBO_MODEL_URI to empty string to prevent Gazebo from downloading models
+    gz_model_uri = SetEnvironmentVariable(name='GAZEBO_MODEL_URI', value=[''])
+
+    gazebo_params_yaml_file = os.path.join(
+        pkg_create3_gazebo_bringup, 'config', 'gazebo_params.yaml')
+
+    # Launch configurations
+    world_path = LaunchConfiguration('world_path')
+    use_gazebo_gui = LaunchConfiguration('use_gazebo_gui')
+
+    # Gazebo server
+    gzserver = ExecuteProcess(
+        cmd=['gzserver',
+             '-s', 'libgazebo_ros_init.so',
+             '-s', 'libgazebo_ros_factory.so',
+             world_path,
+             'extra-gazebo-args', '--ros-args', '--params-file', gazebo_params_yaml_file],
+        output='screen',
+    )
+
+    # Gazebo client
+    gzclient = ExecuteProcess(
+        cmd=['gzclient'],
+        output='screen',
+        condition=IfCondition(use_gazebo_gui),
+    )
+
+    # Define LaunchDescription variable
+    ld = LaunchDescription(ARGUMENTS)
+    # Gazebo processes
+    ld.add_action(gz_resource_path)
+    ld.add_action(gz_model_uri)
+    ld.add_action(gzserver)
+    ld.add_action(gzclient)
+
+    return ld

--- a/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_bumper.cpp
+++ b/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_bumper.cpp
@@ -81,7 +81,11 @@ void GazeboRosBumper::GzPoseCallback(ConstPosesStampedPtr & msg)
   // Find in the message's vector a pose element corresponding to the mobile base's absolute pose
   // identified under the "create3" name.
   const auto i = std::find_if(
-    poses.begin(), poses.end(), [](const auto & pose) -> bool {return pose.name() == "create3";});
+    poses.begin(), poses.end(), [](const auto & pose) -> bool {
+      std::string frame("create3");
+      // Compare end of name to "create3". This works with namespaced frames.
+      return std::equal(frame.rbegin(), frame.rend(), pose.name().rbegin());
+    });
   // If not matches are found, return immediately.
   if (i == poses.end()) {
     return;

--- a/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_docking_status.cpp
+++ b/irobot_create_gazebo/irobot_create_gazebo_plugins/src/gazebo_ros_docking_status.cpp
@@ -46,7 +46,7 @@ void GazeboRosDockingStatus::Load(gazebo::physics::ModelPtr model, sdf::ElementP
     "~/out", rclcpp::SensorDataQoS().reliable());
 
   sub_ = ros_node_->create_subscription<irobot_create_msgs::msg::IrOpcode>(
-    "/ir_opcode", rclcpp::SensorDataQoS(),
+    "ir_opcode", rclcpp::SensorDataQoS(),
     std::bind(&GazeboRosDockingStatus::IrOpcodeCb, this, std::placeholders::_1));
 
   // Set message frame_id

--- a/irobot_create_ignition/irobot_create_ignition_bringup/config/pose_republisher_params.yaml
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/config/pose_republisher_params.yaml
@@ -1,10 +1,11 @@
 ---
-pose_republisher_node:
-  ros__parameters:
-    robot_publisher_topic: sim_ground_truth_pose
-    robot_subscriber_topic: _internal/sim_ground_truth_pose
-    mouse_publisher_topic: _internal/sim_ground_truth_mouse_pose
-    dock_subscriber_topic: _internal/sim_ground_truth_dock_pose
-    dock_publisher_topic: sim_ground_truth_dock_pose
-    ir_emitter_publisher_topic: _internal/sim_ground_truth_ir_emitter_pose
-    ir_receiver_publisher_topic: _internal/sim_ground_truth_ir_receiver_pose
+/**:
+  pose_republisher_node:
+    ros__parameters:
+      robot_publisher_topic: sim_ground_truth_pose
+      robot_subscriber_topic: _internal/sim_ground_truth_pose
+      mouse_publisher_topic: _internal/sim_ground_truth_mouse_pose
+      dock_subscriber_topic: _internal/sim_ground_truth_dock_pose
+      dock_publisher_topic: sim_ground_truth_dock_pose
+      ir_emitter_publisher_topic: _internal/sim_ground_truth_ir_emitter_pose
+      ir_receiver_publisher_topic: _internal/sim_ground_truth_ir_receiver_pose

--- a/irobot_create_ignition/irobot_create_ignition_bringup/config/pose_republisher_params.yaml
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/config/pose_republisher_params.yaml
@@ -1,10 +1,10 @@
 ---
 pose_republisher_node:
   ros__parameters:
-    robot_publisher_topic: /sim_ground_truth_pose
-    robot_subscriber_topic: /_internal/sim_ground_truth_pose
-    mouse_publisher_topic: /_internal/sim_ground_truth_mouse_pose
-    dock_subscriber_topic: /_internal/sim_ground_truth_dock_pose
-    dock_publisher_topic: /sim_ground_truth_dock_pose
-    ir_emitter_publisher_topic: /_internal/sim_ground_truth_ir_emitter_pose
-    ir_receiver_publisher_topic: /_internal/sim_ground_truth_ir_receiver_pose
+    robot_publisher_topic: sim_ground_truth_pose
+    robot_subscriber_topic: _internal/sim_ground_truth_pose
+    mouse_publisher_topic: _internal/sim_ground_truth_mouse_pose
+    dock_subscriber_topic: _internal/sim_ground_truth_dock_pose
+    dock_publisher_topic: sim_ground_truth_dock_pose
+    ir_emitter_publisher_topic: _internal/sim_ground_truth_ir_emitter_pose
+    ir_receiver_publisher_topic: _internal/sim_ground_truth_ir_receiver_pose

--- a/irobot_create_ignition/irobot_create_ignition_bringup/config/sensors_params.yaml
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/config/sensors_params.yaml
@@ -1,37 +1,38 @@
 ---
-sensors_node:
-  ros__parameters:
-    cliff_subscription_topics:
-      - _internal/cliff_front_left/scan
-      - _internal/cliff_front_right/scan
-      - _internal/cliff_side_left/scan
-      - _internal/cliff_side_right/scan
+/**:
+  sensors_node:
+    ros__parameters:
+      cliff_subscription_topics:
+        - _internal/cliff_front_left/scan
+        - _internal/cliff_front_right/scan
+        - _internal/cliff_side_left/scan
+        - _internal/cliff_side_right/scan
 
-    cliff_publish_topics:
-      - _internal/cliff_front_left/event
-      - _internal/cliff_front_right/event
-      - _internal/cliff_side_left/event
-      - _internal/cliff_side_right/event
+      cliff_publish_topics:
+        - _internal/cliff_front_left/event
+        - _internal/cliff_front_right/event
+        - _internal/cliff_side_left/event
+        - _internal/cliff_side_right/event
 
-    ir_scan_subscription_topics:
-      - _internal/ir_intensity_front_center_left/scan
-      - _internal/ir_intensity_front_center_right/scan
-      - _internal/ir_intensity_front_left/scan
-      - _internal/ir_intensity_front_right/scan
-      - _internal/ir_intensity_left/scan
-      - _internal/ir_intensity_right/scan
-      - _internal/ir_intensity_side_left/scan
+      ir_scan_subscription_topics:
+        - _internal/ir_intensity_front_center_left/scan
+        - _internal/ir_intensity_front_center_right/scan
+        - _internal/ir_intensity_front_left/scan
+        - _internal/ir_intensity_front_right/scan
+        - _internal/ir_intensity_left/scan
+        - _internal/ir_intensity_right/scan
+        - _internal/ir_intensity_side_left/scan
 
-    ir_intensity_publish_topics:
-      - _internal/ir_intensity_front_center_left
-      - _internal/ir_intensity_front_center_right
-      - _internal/ir_intensity_front_left
-      - _internal/ir_intensity_front_right
-      - _internal/ir_intensity_left
-      - _internal/ir_intensity_right
-      - _internal/ir_intensity_side_left
+      ir_intensity_publish_topics:
+        - _internal/ir_intensity_front_center_left
+        - _internal/ir_intensity_front_center_right
+        - _internal/ir_intensity_front_left
+        - _internal/ir_intensity_front_right
+        - _internal/ir_intensity_left
+        - _internal/ir_intensity_right
+        - _internal/ir_intensity_side_left
 
-    ir_opcode_sensor_0_fov: 3.839724
-    ir_opcode_sensor_0_range: 0.1
-    ir_opcode_sensor_1_fov: 1.570796
-    ir_opcode_sensor_1_range: 0.5
+      ir_opcode_sensor_0_fov: 3.839724
+      ir_opcode_sensor_0_range: 0.1
+      ir_opcode_sensor_1_fov: 1.570796
+      ir_opcode_sensor_1_range: 0.5

--- a/irobot_create_ignition/irobot_create_ignition_bringup/gui/create3/gui.config
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/gui/create3/gui.config
@@ -103,6 +103,7 @@
 
 <!-- Teleop -->
 <plugin filename="Teleop">
+  <topic>/create3/cmd_vel</topic>
   <ignition-gui>
     <property type="bool" key="showTitleBar">true</property>
     <property type="string" key="state">docked</property>

--- a/irobot_create_ignition/irobot_create_ignition_bringup/gui/create3/gui.config
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/gui/create3/gui.config
@@ -103,7 +103,7 @@
 
 <!-- Teleop -->
 <plugin filename="Teleop">
-  <topic>/create3/cmd_vel</topic>
+  <topic>/cmd_vel</topic>
   <ignition-gui>
     <property type="bool" key="showTitleBar">true</property>
     <property type="string" key="state">docked</property>

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition.launch.py
@@ -44,7 +44,7 @@ ARGUMENTS = [
                           description='Ignition World'),
     DeclareLaunchArgument('robot_name', default_value='create3',
                           description='Robot name'),
-    DeclareLaunchArgument('use_rviz', default_value='true',
+    DeclareLaunchArgument('use_rviz', default_value='false',
                           choices=['true', 'false'], description='Start rviz.'),
     DeclareLaunchArgument('spawn_dock', default_value='true',
                           choices=['true', 'false'],
@@ -87,22 +87,8 @@ def generate_launch_description():
     # Paths
     ign_gazebo_launch = PathJoinSubstitution(
         [pkg_ros_ign_gazebo, 'launch', 'ign_gazebo.launch.py'])
-    ros_ign_bridge_launch = PathJoinSubstitution(
-        [pkg_irobot_create_ignition_bringup, 'launch', 'create3_ros_ignition_bridge.launch.py'])
-    create3_nodes_launch = PathJoinSubstitution(
-        [pkg_irobot_create_common_bringup, 'launch', 'create3_nodes.launch.py'])
-    create3_ignition_nodes_launch = PathJoinSubstitution(
-        [pkg_irobot_create_ignition_bringup, 'launch', 'create3_ignition_nodes.launch.py'])
-    robot_description_launch = PathJoinSubstitution(
-        [pkg_irobot_create_common_bringup, 'launch', 'robot_description.launch.py'])
-    dock_description_launch = PathJoinSubstitution(
-        [pkg_irobot_create_common_bringup, 'launch', 'dock_description.launch.py'])
     rviz2_launch = PathJoinSubstitution(
         [pkg_irobot_create_common_bringup, 'launch', 'rviz2.launch.py'])
-
-    # Launch configurations
-    x, y, z = LaunchConfiguration('x'), LaunchConfiguration('y'), LaunchConfiguration('z')
-    yaw = LaunchConfiguration('yaw')
 
     # Ignition gazebo
     ignition_gazebo = IncludeLaunchDescription(
@@ -110,7 +96,7 @@ def generate_launch_description():
         launch_arguments=[
             ('ign_args', [LaunchConfiguration('world'),
                           '.sdf',
-                          ' -v 4',
+                          ' -v 6',
                           ' --gui-config ',
                           PathJoinSubstitution([pkg_irobot_create_ignition_bringup,
                                                 'gui', 'create3', 'gui.config'])])
@@ -122,69 +108,19 @@ def generate_launch_description():
         condition=IfCondition(LaunchConfiguration('use_rviz')),
     )
 
-    x_dock = OffsetParser(x, 0.157)
-    yaw_dock = OffsetParser(yaw, 3.1416)
-    dock_description = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([dock_description_launch]),
-        condition=IfCondition(LaunchConfiguration('spawn_dock')),
-        # The robot starts docked
-        launch_arguments={'x': x_dock, 'y': y, 'z': z, 'yaw': yaw_dock,
-                          'gazebo': 'ignition'}.items(),
-    )
-
-    robot_description = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([robot_description_launch]),
-        launch_arguments={'gazebo': 'ignition'}.items()
-    )
-
-    # Create3
-    spawn_robot = Node(package='ros_ign_gazebo', executable='create',
-                       arguments=['-name', LaunchConfiguration('robot_name'),
-                                  '-x', x,
-                                  '-y', y,
-                                  '-z', z,
-                                  '-Y', '0.0',
-                                  '-topic', 'robot_description'],
-                       output='screen')
-
-    # Dock
-    spawn_dock = Node(package='ros_ign_gazebo', executable='create',
-                      arguments=['-name', 'standard_dock',
-                                 '-x', x_dock,
-                                 '-y', y,
-                                 '-z', z,
-                                 '-Y', '3.141592',
-                                 '-topic', 'standard_dock_description'],
-                      output='screen')
-
-    # ROS Ign bridge
-    ros_ign_bridge = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([ros_ign_bridge_launch]),
-        launch_arguments=[('world', LaunchConfiguration('world')),
-                          ('robot_name', LaunchConfiguration('robot_name'))]
-    )
-
-    # Create3 nodes
-    create3_nodes = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([create3_nodes_launch])
-    )
-
-    create3_ignition_nodes = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([create3_ignition_nodes_launch]),
-        launch_arguments=[('robot_name', LaunchConfiguration('robot_name'))]
-    )
+    # clock bridge
+    clock_bridge = Node(package='ros_gz_bridge', executable='parameter_bridge',
+                        name='clock_bridge',
+                        output='screen',
+                        arguments=[
+                            '/clock' + '@rosgraph_msgs/msg/Clock' + '[ignition.msgs.Clock'
+                        ])
 
     # Create launch description and add actions
     ld = LaunchDescription(ARGUMENTS)
     ld.add_action(ign_resource_path)
     ld.add_action(ign_gui_plugin_path)
     ld.add_action(ignition_gazebo)
-    ld.add_action(ros_ign_bridge)
+    ld.add_action(clock_bridge)
     ld.add_action(rviz2)
-    ld.add_action(robot_description)
-    ld.add_action(dock_description)
-    ld.add_action(spawn_robot)
-    ld.add_action(spawn_dock)
-    ld.add_action(create3_nodes)
-    ld.add_action(create3_ignition_nodes)
     return ld

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition.launch.py
@@ -6,7 +6,6 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription
-from launch.conditions import IfCondition, LaunchConfigurationNotEquals
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 
@@ -14,7 +13,7 @@ from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 ARGUMENTS = [
     DeclareLaunchArgument('robot_name', default_value='create3',
                           description='Robot name'),
-    DeclareLaunchArgument('use_rviz', default_value='false',
+    DeclareLaunchArgument('use_rviz', default_value='true',
                           choices=['true', 'false'], description='Start rviz.'),
     DeclareLaunchArgument('world', default_value='depot',
                           description='Ignition World'),
@@ -30,14 +29,10 @@ def generate_launch_description():
     # Directories
     pkg_irobot_create_ignition_bringup = get_package_share_directory(
         'irobot_create_ignition_bringup')
-    pkg_irobot_create_common_bringup = get_package_share_directory(
-        'irobot_create_common_bringup')
 
     # Paths
     ignition_launch = PathJoinSubstitution(
         [pkg_irobot_create_ignition_bringup, 'launch', 'ignition.launch.py'])
-    rviz2_launch = PathJoinSubstitution(
-        [pkg_irobot_create_common_bringup, 'launch', 'rviz2.launch.py'])
     robot_spawn_launch = PathJoinSubstitution(
         [pkg_irobot_create_ignition_bringup, 'launch', 'create3_spawn.launch.py'])
 
@@ -48,24 +43,18 @@ def generate_launch_description():
         ]
     )
 
-    rviz2 = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([rviz2_launch]),
-        condition=IfCondition(LaunchConfiguration('use_rviz')),
-    )
-
     robot_spawn = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([robot_spawn_launch]),
         launch_arguments=[
             ('robot_name', LaunchConfiguration('robot_name')),
+            ('use_rviz', LaunchConfiguration('use_rviz')),
             ('x', LaunchConfiguration('x')),
             ('y', LaunchConfiguration('y')),
             ('z', LaunchConfiguration('z')),
-            ('yaw', LaunchConfiguration('yaw'))],
-        condition=LaunchConfigurationNotEquals('robot_name', ''))
+            ('yaw', LaunchConfiguration('yaw'))])
 
     # Create launch description and add actions
     ld = LaunchDescription(ARGUMENTS)
     ld.add_action(ignition)
-    ld.add_action(rviz2)
     ld.add_action(robot_spawn)
     return ld

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition.launch.py
@@ -13,6 +13,8 @@ from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 ARGUMENTS = [
     DeclareLaunchArgument('robot_name', default_value='create3',
                           description='Robot name'),
+    DeclareLaunchArgument('namespace', default_value='',
+                          description='Robot namespace'),
     DeclareLaunchArgument('use_rviz', default_value='true',
                           choices=['true', 'false'], description='Start rviz.'),
     DeclareLaunchArgument('world', default_value='depot',
@@ -47,6 +49,7 @@ def generate_launch_description():
         PythonLaunchDescriptionSource([robot_spawn_launch]),
         launch_arguments=[
             ('robot_name', LaunchConfiguration('robot_name')),
+            ('namespace', LaunchConfiguration('namespace')),
             ('use_rviz', LaunchConfiguration('use_rviz')),
             ('x', LaunchConfiguration('x')),
             ('y', LaunchConfiguration('y')),

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition.launch.py
@@ -11,8 +11,6 @@ from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 
 
 ARGUMENTS = [
-    DeclareLaunchArgument('robot_name', default_value='create3',
-                          description='Robot name'),
     DeclareLaunchArgument('namespace', default_value='',
                           description='Robot namespace'),
     DeclareLaunchArgument('use_rviz', default_value='true',
@@ -48,7 +46,6 @@ def generate_launch_description():
     robot_spawn = IncludeLaunchDescription(
         PythonLaunchDescriptionSource([robot_spawn_launch]),
         launch_arguments=[
-            ('robot_name', LaunchConfiguration('robot_name')),
             ('namespace', LaunchConfiguration('namespace')),
             ('use_rviz', LaunchConfiguration('use_rviz')),
             ('x', LaunchConfiguration('x')),

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition.launch.py
@@ -1,54 +1,23 @@
 # Copyright 2021 Clearpath Robotics, Inc.
 # @author Roni Kreinin (rkreinin@clearpathrobotics.com)
 
-import os
-
-from pathlib import Path
-
 from ament_index_python.packages import get_package_share_directory
 
-from launch import LaunchContext, LaunchDescription, SomeSubstitutionsType, Substitution
+from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable
-from launch.conditions import IfCondition
+from launch.actions import IncludeLaunchDescription
+from launch.conditions import IfCondition, LaunchConfigurationNotEquals
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
-from launch_ros.actions import Node
-
-
-class OffsetParser(Substitution):
-    def __init__(
-            self,
-            number: SomeSubstitutionsType,
-            offset: float,
-    ) -> None:
-        self.__number = number
-        self.__offset = offset
-
-    def perform(
-            self,
-            context: LaunchContext = None,
-    ) -> str:
-        number = float(self.__number.perform(context))
-        return f'{number + self.__offset}'
 
 
 ARGUMENTS = [
-    DeclareLaunchArgument('bridge', default_value='true',
-                          choices=['true', 'false'],
-                          description='Use ros_ign_bridge'),
-    DeclareLaunchArgument('use_sim_time', default_value='true',
-                          choices=['true', 'false'],
-                          description='use_sim_time'),
-    DeclareLaunchArgument('world', default_value='depot',
-                          description='Ignition World'),
     DeclareLaunchArgument('robot_name', default_value='create3',
                           description='Robot name'),
     DeclareLaunchArgument('use_rviz', default_value='false',
                           choices=['true', 'false'], description='Start rviz.'),
-    DeclareLaunchArgument('spawn_dock', default_value='true',
-                          choices=['true', 'false'],
-                          description='Spawn the standard dock model.'),
+    DeclareLaunchArgument('world', default_value='depot',
+                          description='Ignition World'),
 ]
 
 for pose_element in ['x', 'y', 'z', 'yaw']:
@@ -59,47 +28,23 @@ for pose_element in ['x', 'y', 'z', 'yaw']:
 def generate_launch_description():
 
     # Directories
-    pkg_irobot_create_common_bringup = get_package_share_directory(
-        'irobot_create_common_bringup')
     pkg_irobot_create_ignition_bringup = get_package_share_directory(
         'irobot_create_ignition_bringup')
-    pkg_irobot_create_ignition_plugins = get_package_share_directory(
-        'irobot_create_ignition_plugins')
-    pkg_irobot_create_description = get_package_share_directory(
-        'irobot_create_description')
-    pkg_ros_ign_gazebo = get_package_share_directory(
-        'ros_ign_gazebo')
-
-    # Set Ignition resource path
-    ign_resource_path = SetEnvironmentVariable(name='IGN_GAZEBO_RESOURCE_PATH',
-                                               value=[os.path.join(
-                                                      pkg_irobot_create_ignition_bringup,
-                                                      'worlds'), ':' +
-                                                      str(Path(
-                                                          pkg_irobot_create_description).
-                                                          parent.resolve())])
-
-    ign_gui_plugin_path = SetEnvironmentVariable(name='IGN_GUI_PLUGIN_PATH',
-                                                 value=[os.path.join(
-                                                        pkg_irobot_create_ignition_plugins,
-                                                        'lib')])
+    pkg_irobot_create_common_bringup = get_package_share_directory(
+        'irobot_create_common_bringup')
 
     # Paths
-    ign_gazebo_launch = PathJoinSubstitution(
-        [pkg_ros_ign_gazebo, 'launch', 'ign_gazebo.launch.py'])
+    ignition_launch = PathJoinSubstitution(
+        [pkg_irobot_create_ignition_bringup, 'launch', 'ignition.launch.py'])
     rviz2_launch = PathJoinSubstitution(
         [pkg_irobot_create_common_bringup, 'launch', 'rviz2.launch.py'])
+    robot_spawn_launch = PathJoinSubstitution(
+        [pkg_irobot_create_ignition_bringup, 'launch', 'create3_spawn.launch.py'])
 
-    # Ignition gazebo
-    ignition_gazebo = IncludeLaunchDescription(
-        PythonLaunchDescriptionSource([ign_gazebo_launch]),
+    ignition = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([ignition_launch]),
         launch_arguments=[
-            ('ign_args', [LaunchConfiguration('world'),
-                          '.sdf',
-                          ' -v 6',
-                          ' --gui-config ',
-                          PathJoinSubstitution([pkg_irobot_create_ignition_bringup,
-                                                'gui', 'create3', 'gui.config'])])
+            ('world', LaunchConfiguration('world'))
         ]
     )
 
@@ -108,19 +53,19 @@ def generate_launch_description():
         condition=IfCondition(LaunchConfiguration('use_rviz')),
     )
 
-    # clock bridge
-    clock_bridge = Node(package='ros_gz_bridge', executable='parameter_bridge',
-                        name='clock_bridge',
-                        output='screen',
-                        arguments=[
-                            '/clock' + '@rosgraph_msgs/msg/Clock' + '[ignition.msgs.Clock'
-                        ])
+    robot_spawn = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([robot_spawn_launch]),
+        launch_arguments=[
+            ('robot_name', LaunchConfiguration('robot_name')),
+            ('x', LaunchConfiguration('x')),
+            ('y', LaunchConfiguration('y')),
+            ('z', LaunchConfiguration('z')),
+            ('yaw', LaunchConfiguration('yaw'))],
+        condition=LaunchConfigurationNotEquals('robot_name', ''))
 
     # Create launch description and add actions
     ld = LaunchDescription(ARGUMENTS)
-    ld.add_action(ign_resource_path)
-    ld.add_action(ign_gui_plugin_path)
-    ld.add_action(ignition_gazebo)
-    ld.add_action(clock_bridge)
+    ld.add_action(ignition)
     ld.add_action(rviz2)
+    ld.add_action(robot_spawn)
     return ld

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition_nodes.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition_nodes.launch.py
@@ -10,7 +10,9 @@ from launch_ros.actions import Node
 
 ARGUMENTS = [
     DeclareLaunchArgument('robot_name', default_value='create3',
-                          description='Robot name')
+                          description='Robot name'),
+    DeclareLaunchArgument('dock_name', default_value='standard_dock',
+                          description='Dock name')
 ]
 
 
@@ -31,6 +33,7 @@ def generate_launch_description():
         executable='pose_republisher_node',
         parameters=[pose_republisher_params_yaml_file,
                     {'robot_name': LaunchConfiguration('robot_name')},
+                    {'dock_name': LaunchConfiguration('dock_name')},
                     {'use_sim_time': True}],
         output='screen',
     )

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition_nodes.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition_nodes.launch.py
@@ -8,8 +8,6 @@ from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 
-from nav2_common.launch import RewrittenYaml
-
 ARGUMENTS = [
     DeclareLaunchArgument('robot_name', default_value='create3',
                           description='Robot name')
@@ -20,31 +18,18 @@ def generate_launch_description():
 
     # Directories
     pkg_create3_ignition_bringup = get_package_share_directory('irobot_create_ignition_bringup')
-    namespace = LaunchConfiguration('namespace', default='')
 
     pose_republisher_params_yaml_file = PathJoinSubstitution(
         [pkg_create3_ignition_bringup, 'config', 'pose_republisher_params.yaml'])
     sensors_params_yaml_file = PathJoinSubstitution(
         [pkg_create3_ignition_bringup, 'config', 'sensors_params.yaml'])
 
-    namespaced_pose_republisher_params_yaml_file = RewrittenYaml(
-        source_file=pose_republisher_params_yaml_file,
-        root_key=namespace,
-        param_rewrites={},
-        convert_types=True)
-
-    namespaced_sensors_params_yaml_file = RewrittenYaml(
-        source_file=sensors_params_yaml_file,
-        root_key=namespace,
-        param_rewrites={},
-        convert_types=True)
-
     # Pose republisher
     pose_republisher_node = Node(
         package='irobot_create_ignition_toolbox',
         name='pose_republisher_node',
         executable='pose_republisher_node',
-        parameters=[namespaced_pose_republisher_params_yaml_file,
+        parameters=[pose_republisher_params_yaml_file,
                     {'robot_name': LaunchConfiguration('robot_name')},
                     {'use_sim_time': True}],
         output='screen',
@@ -55,7 +40,7 @@ def generate_launch_description():
         package='irobot_create_ignition_toolbox',
         name='sensors_node',
         executable='sensors_node',
-        parameters=[namespaced_sensors_params_yaml_file,
+        parameters=[sensors_params_yaml_file,
                     {'use_sim_time': True}],
         output='screen',
     )

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition_nodes.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ignition_nodes.launch.py
@@ -8,6 +8,8 @@ from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 
+from nav2_common.launch import RewrittenYaml
+
 ARGUMENTS = [
     DeclareLaunchArgument('robot_name', default_value='create3',
                           description='Robot name')
@@ -18,18 +20,31 @@ def generate_launch_description():
 
     # Directories
     pkg_create3_ignition_bringup = get_package_share_directory('irobot_create_ignition_bringup')
+    namespace = LaunchConfiguration('namespace', default='')
 
     pose_republisher_params_yaml_file = PathJoinSubstitution(
         [pkg_create3_ignition_bringup, 'config', 'pose_republisher_params.yaml'])
     sensors_params_yaml_file = PathJoinSubstitution(
         [pkg_create3_ignition_bringup, 'config', 'sensors_params.yaml'])
 
+    namespaced_pose_republisher_params_yaml_file = RewrittenYaml(
+        source_file=pose_republisher_params_yaml_file,
+        root_key=namespace,
+        param_rewrites={},
+        convert_types=True)
+
+    namespaced_sensors_params_yaml_file = RewrittenYaml(
+        source_file=sensors_params_yaml_file,
+        root_key=namespace,
+        param_rewrites={},
+        convert_types=True)
+
     # Pose republisher
     pose_republisher_node = Node(
         package='irobot_create_ignition_toolbox',
         name='pose_republisher_node',
         executable='pose_republisher_node',
-        parameters=[pose_republisher_params_yaml_file,
+        parameters=[namespaced_pose_republisher_params_yaml_file,
                     {'robot_name': LaunchConfiguration('robot_name')},
                     {'use_sim_time': True}],
         output='screen',
@@ -40,7 +55,7 @@ def generate_launch_description():
         package='irobot_create_ignition_toolbox',
         name='sensors_node',
         executable='sensors_node',
-        parameters=[sensors_params_yaml_file,
+        parameters=[namespaced_sensors_params_yaml_file,
                     {'use_sim_time': True}],
         output='screen',
     )

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ros_ignition_bridge.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ros_ignition_bridge.launch.py
@@ -3,7 +3,6 @@
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.conditions import IfCondition
 from launch.substitutions import LaunchConfiguration
 
 from launch_ros.actions import Node
@@ -40,18 +39,8 @@ def generate_launch_description():
         'ir_intensity_side_left',
     ]
 
-    # clock bridge
-    clock_bridge = Node(package='ros_ign_bridge', executable='parameter_bridge',
-                        namespace=namespace,
-                        name='clock_bridge',
-                        output='screen',
-                        arguments=[
-                            '/clock' + '@rosgraph_msgs/msg/Clock' + '[ignition.msgs.Clock'
-                        ],
-                        condition=IfCondition(use_sim_time))
-
     # cmd_vel bridge
-    cmd_vel_bridge = Node(package='ros_ign_bridge', executable='parameter_bridge',
+    cmd_vel_bridge = Node(package='ros_gz_bridge', executable='parameter_bridge',
                           name='cmd_vel_bridge',
                           output='screen',
                           parameters=[{
@@ -64,13 +53,13 @@ def generate_launch_description():
                                ']ignition.msgs.Twist']
                           ],
                           remappings=[
+                              ('/cmd_vel', 'cmd_vel'),
                               (['/model/', LaunchConfiguration('robot_name'), '/cmd_vel'],
                                'diffdrive_controller/cmd_vel_unstamped')
                           ])
 
     # Pose bridge
-    pose_bridge = Node(package='ros_ign_bridge', executable='parameter_bridge',
-                       namespace=namespace,
+    pose_bridge = Node(package='ros_gz_bridge', executable='parameter_bridge',
                        name='pose_bridge',
                        output='screen',
                        parameters=[{
@@ -86,14 +75,13 @@ def generate_launch_description():
                        ],
                        remappings=[
                            (['/model/', LaunchConfiguration('robot_name'), '/pose'],
-                            '/_internal/sim_ground_truth_pose'),
+                            '_internal/sim_ground_truth_pose'),
                            ('/model/standard_dock/pose',
-                            '/_internal/sim_ground_truth_dock_pose')
+                            '_internal/sim_ground_truth_dock_pose')
                        ])
 
     # odom to base_link transform bridge
-    odom_base_tf_bridge = Node(package='ros_ign_bridge', executable='parameter_bridge',
-                               namespace=namespace,
+    odom_base_tf_bridge = Node(package='ros_gz_bridge', executable='parameter_bridge',
                                name='odom_base_tf_bridge',
                                output='screen',
                                parameters=[{
@@ -105,12 +93,11 @@ def generate_launch_description():
                                     '[ignition.msgs.Pose_V']
                                ],
                                remappings=[
-                                   (['/model/', LaunchConfiguration('robot_name'), '/tf'], '/tf')
+                                   (['/model/', LaunchConfiguration('robot_name'), '/tf'], 'tf')
                                ])
 
     # Bumper contact sensor bridge
-    bumper_contact_bridge = Node(package='ros_ign_bridge', executable='parameter_bridge',
-                                 namespace=namespace,
+    bumper_contact_bridge = Node(package='ros_gz_bridge', executable='parameter_bridge',
                                  name='bumper_contact_bridge',
                                  output='screen',
                                  parameters=[{
@@ -125,12 +112,11 @@ def generate_launch_description():
                                  remappings=[
                                      (['/model/', LaunchConfiguration('robot_name'),
                                       '/bumper_contact'],
-                                      '/bumper_contact')
+                                      'bumper_contact')
                                  ])
 
     # Cliff bridge
-    cliff_bridge = Node(package='ros_ign_bridge', executable='parameter_bridge',
-                        namespace=namespace,
+    cliff_bridge = Node(package='ros_gz_bridge', executable='parameter_bridge',
                         name='cliff_bridge',
                         output='screen',
                         parameters=[{
@@ -147,12 +133,12 @@ def generate_launch_description():
                             (['/world/', LaunchConfiguration('world'),
                               '/model/', LaunchConfiguration('robot_name'),
                               '/link/base_link/sensor/' + cliff + '/scan'],
-                             '/_internal/' + cliff + '/scan')
+                             '_internal/' + cliff + '/scan')
                             for cliff in cliff_sensors
                         ])
+
     # IR intensity bridge
-    ir_intensity_bridge = Node(package='ros_ign_bridge', executable='parameter_bridge',
-                               namespace=namespace,
+    ir_intensity_bridge = Node(package='ros_gz_bridge', executable='parameter_bridge',
                                name='ir_intensity_bridge',
                                output='screen',
                                parameters=[{
@@ -169,12 +155,11 @@ def generate_launch_description():
                                    (['/world/', LaunchConfiguration('world'),
                                      '/model/', LaunchConfiguration('robot_name'),
                                      '/link/' + ir + '/sensor/' + ir + '/scan'],
-                                    '/_internal/' + ir + '/scan') for ir in ir_intensity_sensors
+                                    '_internal/' + ir + '/scan') for ir in ir_intensity_sensors
                                ])
 
     # Buttons message bridge
-    buttons_msg_bridge = Node(package='ros_ign_bridge', executable='parameter_bridge',
-                              namespace=namespace,
+    buttons_msg_bridge = Node(package='ros_gz_bridge', executable='parameter_bridge',
                               name='buttons_msg_bridge',
                               output='screen',
                               parameters=[{
@@ -184,11 +169,13 @@ def generate_launch_description():
                                   ['/create3/buttons' +
                                    '@std_msgs/msg/Int32' +
                                    '[ignition.msgs.Int32']
+                              ],
+                              remappings=[
+                                ('/create3/buttons', 'create3_buttons')
                               ])
 
     # Create launch description and add actions
     ld = LaunchDescription(ARGUMENTS)
-    ld.add_action(clock_bridge)
     ld.add_action(cmd_vel_bridge)
     ld.add_action(pose_bridge)
     ld.add_action(odom_base_tf_bridge)

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ros_ignition_bridge.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ros_ignition_bridge.launch.py
@@ -13,7 +13,9 @@ ARGUMENTS = [
                           description='Use sim time'),
     DeclareLaunchArgument('robot_name', default_value='create3',
                           description='Ignition model name'),
-    DeclareLaunchArgument('namespace', default_value=LaunchConfiguration('robot_name'),
+    DeclareLaunchArgument('dock_name', default_value='standard_dock',
+                          description='Ignition model name'),
+    DeclareLaunchArgument('namespace', default_value='',
                           description='Robot namespace'),
     DeclareLaunchArgument('world', default_value='depot',
                           description='World name')
@@ -23,6 +25,7 @@ ARGUMENTS = [
 def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time')
     robot_name = LaunchConfiguration('robot_name')
+    dock_name = LaunchConfiguration('dock_name')
     namespace = LaunchConfiguration('namespace')
     world = LaunchConfiguration('world')
 
@@ -76,14 +79,14 @@ def generate_launch_description():
                            ['/model/', robot_name, '/pose' +
                             '@tf2_msgs/msg/TFMessage' +
                             '[ignition.msgs.Pose_V'],
-                           ['/model/', robot_name, '/standard_dock/pose' +
+                           ['/model/', dock_name, '/pose' +
                             '@tf2_msgs/msg/TFMessage' +
                             '[ignition.msgs.Pose_V']
                        ],
                        remappings=[
                            (['/model/', robot_name, '/pose'],
                             '_internal/sim_ground_truth_pose'),
-                           (['/model/', robot_name, '/standard_dock/pose'],
+                           (['/model/', dock_name, '/pose'],
                             '_internal/sim_ground_truth_dock_pose')
                        ])
 

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ros_ignition_bridge.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ros_ignition_bridge.launch.py
@@ -72,8 +72,8 @@ def generate_launch_description():
                             '@tf2_msgs/msg/TFMessage' +
                             '[ignition.msgs.Pose_V'],
                            ['/model/', robot_name, '/standard_dock/pose' +
-                           '@tf2_msgs/msg/TFMessage' +
-                           '[ignition.msgs.Pose_V']
+                            '@tf2_msgs/msg/TFMessage' +
+                            '[ignition.msgs.Pose_V']
                        ],
                        remappings=[
                            (['/model/', robot_name, '/pose'],
@@ -149,15 +149,15 @@ def generate_launch_description():
              }],
              arguments=[
                  ['/world/', world,
-                 '/model/', robot_name,
-                 '/link/' + ir + '/sensor/' + ir + '/scan' +
-                 '@sensor_msgs/msg/LaserScan[ignition.msgs.LaserScan']
+                  '/model/', robot_name,
+                  '/link/' + ir + '/sensor/' + ir + '/scan' +
+                  '@sensor_msgs/msg/LaserScan[ignition.msgs.LaserScan']
              ],
              remappings=[
                  (['/world/', world,
                      '/model/', robot_name,
                      '/link/' + ir + '/sensor/' + ir + '/scan'],
-                 '_internal/' + ir + '/scan')
+                  '_internal/' + ir + '/scan')
              ]) for ir in ir_intensity_sensors
     ])
 

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ros_ignition_bridge.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ros_ignition_bridge.launch.py
@@ -57,15 +57,15 @@ def generate_launch_description():
         }],
         arguments=[
             [namespace,
-            '/cmd_vel' + '@geometry_msgs/msg/Twist' + '[ignition.msgs.Twist'],
+             '/cmd_vel' + '@geometry_msgs/msg/Twist' + '[ignition.msgs.Twist'],
             ['/model/', robot_name, '/cmd_vel' +
-            '@geometry_msgs/msg/Twist' +
-            ']ignition.msgs.Twist']
+             '@geometry_msgs/msg/Twist' +
+             ']ignition.msgs.Twist']
         ],
         remappings=[
             ([namespace, '/cmd_vel'], 'cmd_vel'),
             (['/model/', robot_name, '/cmd_vel'],
-            'diffdrive_controller/cmd_vel_unstamped')
+             'diffdrive_controller/cmd_vel_unstamped')
         ])
 
     # Pose bridge
@@ -182,8 +182,8 @@ def generate_launch_description():
         }],
         arguments=[
             [namespace, '/create3_buttons' +
-            '@std_msgs/msg/Int32' +
-            '[ignition.msgs.Int32'],
+             '@std_msgs/msg/Int32' +
+             '[ignition.msgs.Int32'],
         ],
         remappings=[
             ([namespace, '/create3_buttons'], '_internal/create3_buttons'),

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ros_ignition_bridge.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ros_ignition_bridge.launch.py
@@ -71,14 +71,14 @@ def generate_launch_description():
                            ['/model/', robot_name, '/pose' +
                             '@tf2_msgs/msg/TFMessage' +
                             '[ignition.msgs.Pose_V'],
-                           '/model/standard_dock/pose' +
+                           ['/model/', robot_name, '/standard_dock/pose' +
                            '@tf2_msgs/msg/TFMessage' +
-                           '[ignition.msgs.Pose_V'
+                           '[ignition.msgs.Pose_V']
                        ],
                        remappings=[
                            (['/model/', robot_name, '/pose'],
                             '_internal/sim_ground_truth_pose'),
-                           ('/model/standard_dock/pose',
+                           (['/model/', robot_name, '/standard_dock/pose'],
                             '_internal/sim_ground_truth_dock_pose')
                        ])
 

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ros_ignition_bridge.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ros_ignition_bridge.launch.py
@@ -13,6 +13,8 @@ ARGUMENTS = [
                           description='Use sim time'),
     DeclareLaunchArgument('robot_name', default_value='create3',
                           description='Ignition model name'),
+    DeclareLaunchArgument('namespace', default_value=LaunchConfiguration('robot_name'),
+                          description='Robot namespace'),
     DeclareLaunchArgument('world', default_value='depot',
                           description='World name')
 ]
@@ -21,6 +23,7 @@ ARGUMENTS = [
 def generate_launch_description():
     use_sim_time = LaunchConfiguration('use_sim_time')
     robot_name = LaunchConfiguration('robot_name')
+    namespace = LaunchConfiguration('namespace')
     world = LaunchConfiguration('world')
 
     cliff_sensors = [
@@ -41,24 +44,26 @@ def generate_launch_description():
     ]
 
     # cmd_vel bridge
-    cmd_vel_bridge = Node(package='ros_gz_bridge', executable='parameter_bridge',
-                          name='cmd_vel_bridge',
-                          output='screen',
-                          parameters=[{
-                              'use_sim_time': use_sim_time
-                          }],
-                          arguments=[
-                              [robot_name,
-                               '/cmd_vel' + '@geometry_msgs/msg/Twist' + '[ignition.msgs.Twist'],
-                              ['/model/', robot_name, '/cmd_vel' +
-                               '@geometry_msgs/msg/Twist' +
-                               ']ignition.msgs.Twist']
-                          ],
-                          remappings=[
-                              ([robot_name, '/cmd_vel'], 'cmd_vel'),
-                              (['/model/', robot_name, '/cmd_vel'],
-                               'diffdrive_controller/cmd_vel_unstamped')
-                          ])
+    cmd_vel_bridge = Node(
+        package='ros_gz_bridge',
+        executable='parameter_bridge',
+        name='cmd_vel_bridge',
+        output='screen',
+        parameters=[{
+            'use_sim_time': use_sim_time
+        }],
+        arguments=[
+            [namespace,
+            '/cmd_vel' + '@geometry_msgs/msg/Twist' + '[ignition.msgs.Twist'],
+            ['/model/', robot_name, '/cmd_vel' +
+            '@geometry_msgs/msg/Twist' +
+            ']ignition.msgs.Twist']
+        ],
+        remappings=[
+            ([namespace, '/cmd_vel'], 'cmd_vel'),
+            (['/model/', robot_name, '/cmd_vel'],
+            'diffdrive_controller/cmd_vel_unstamped')
+        ])
 
     # Pose bridge
     pose_bridge = Node(package='ros_gz_bridge', executable='parameter_bridge',
@@ -127,9 +132,9 @@ def generate_launch_description():
              }],
              arguments=[
                  ['/world/', world,
-                     '/model/', robot_name,
-                     '/link/base_link/sensor/' + cliff + '/scan' +
-                     '@sensor_msgs/msg/LaserScan[ignition.msgs.LaserScan']
+                  '/model/', robot_name,
+                  '/link/base_link/sensor/' + cliff + '/scan' +
+                  '@sensor_msgs/msg/LaserScan[ignition.msgs.LaserScan']
              ],
              remappings=[
                  (['/world/', world,
@@ -162,20 +167,23 @@ def generate_launch_description():
     ])
 
     # Buttons message bridge
-    buttons_msg_bridge = Node(package='ros_gz_bridge', executable='parameter_bridge',
-                              name='buttons_msg_bridge',
-                              output='screen',
-                              parameters=[{
-                                   'use_sim_time': use_sim_time
-                              }],
-                              arguments=[
-                                  ['/model/', robot_name, '/create3_buttons' +
-                                   '@std_msgs/msg/Int32' +
-                                   '[ignition.msgs.Int32']
-                              ],
-                              remappings=[
-                                (['/model/', robot_name, '/create3_buttons'], '_create3_buttons')
-                              ])
+    buttons_msg_bridge = Node(
+        package='ros_gz_bridge',
+        executable='parameter_bridge',
+        name='buttons_msg_bridge',
+        output='screen',
+        parameters=[{
+            'use_sim_time': use_sim_time
+        }],
+        arguments=[
+            [namespace, '/create3_buttons' +
+            '@std_msgs/msg/Int32' +
+            '[ignition.msgs.Int32'],
+        ],
+        remappings=[
+            ([namespace, '/create3_buttons'], '_internal/create3_buttons'),
+        ]
+    )
 
     # Create launch description and add actions
     ld = LaunchDescription(ARGUMENTS)

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ros_ignition_bridge.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_ros_ignition_bridge.launch.py
@@ -114,13 +114,13 @@ def generate_launch_description():
                                      'use_sim_time': use_sim_time
                                  }],
                                  arguments=[
-                                     ['/model/', robot_name,
+                                     [namespace,
                                       '/bumper_contact' +
-                                      '@ros_ign_interfaces/msg/Contacts' +
+                                      '@ros_gz_interfaces/msg/Contacts' +
                                       '[ignition.msgs.Contacts']
                                  ],
                                  remappings=[
-                                     (['/model/', robot_name,
+                                     ([namespace,
                                       '/bumper_contact'],
                                       'bumper_contact')
                                  ])
@@ -131,7 +131,8 @@ def generate_launch_description():
              name=cliff + '_bridge',
              output='screen',
              parameters=[{
-                 'use_sim_time': use_sim_time
+                 'use_sim_time': use_sim_time,
+                 'lazy': True
              }],
              arguments=[
                  ['/world/', world,
@@ -153,7 +154,8 @@ def generate_launch_description():
              name=ir + '_bridge',
              output='screen',
              parameters=[{
-                 'use_sim_time': use_sim_time
+                 'use_sim_time': use_sim_time,
+                 'lazy': True
              }],
              arguments=[
                  ['/world/', world,

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_spawn.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_spawn.launch.py
@@ -93,7 +93,6 @@ def generate_launch_description():
             condition=IfCondition(LaunchConfiguration('spawn_dock')),
             # The robot starts docked
             launch_arguments={'x': x_dock, 'y': y, 'z': z, 'yaw': yaw_dock,
-                              'namespace': namespace,
                               'gazebo': 'ignition'}.items(),
         ),
 
@@ -121,7 +120,7 @@ def generate_launch_description():
         Node(
             package='ros_ign_gazebo',
             executable='create',
-            arguments=['-name', [LaunchConfiguration('robot_name'), '/standard_dock'],
+            arguments=['-name', [LaunchConfiguration('robot_name'), '_standard_dock'],
                        '-x', x_dock,
                        '-y', y,
                        '-z', z,

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_spawn.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_spawn.launch.py
@@ -25,6 +25,8 @@ ARGUMENTS = [
                           description='Ignition World'),
     DeclareLaunchArgument('robot_name', default_value='create3',
                           description='Robot name'),
+    DeclareLaunchArgument('namespace', default_value=LaunchConfiguration('robot_name'),
+                          description='Robot namespace'),
     DeclareLaunchArgument('use_rviz', default_value='true',
                           choices=['true', 'false'], description='Start rviz.'),
     DeclareLaunchArgument('spawn_dock', default_value='true',
@@ -60,7 +62,7 @@ def generate_launch_description():
         [pkg_irobot_create_common_bringup, 'launch', 'rviz2.launch.py'])
 
     # Launch configurations
-    namespace = LaunchConfiguration('robot_name')
+    namespace = LaunchConfiguration('namespace')
     x, y, z = LaunchConfiguration('x'), LaunchConfiguration('y'), LaunchConfiguration('z')
     yaw = LaunchConfiguration('yaw')
 
@@ -87,8 +89,7 @@ def generate_launch_description():
         # Robot description
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource([robot_description_launch]),
-            launch_arguments={'gazebo': 'ignition',
-                              'robot_name': LaunchConfiguration('robot_name')}.items()
+            launch_arguments={'gazebo': 'ignition'}.items()
         ),
 
         # Spawn Create 3
@@ -121,20 +122,17 @@ def generate_launch_description():
         # ROS Ign Bridge
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource([ros_ign_bridge_launch]),
-            launch_arguments=[('world', LaunchConfiguration('world')),
-                              ('robot_name', LaunchConfiguration('robot_name'))]
+            launch_arguments=[('world', LaunchConfiguration('world'))]
         ),
 
         # Create 3 nodes
         IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([create3_nodes_launch]),
-            launch_arguments=[('robot_name', LaunchConfiguration('robot_name'))]
+            PythonLaunchDescriptionSource([create3_nodes_launch])
         ),
 
         # Create 3 Ignition nodes
         IncludeLaunchDescription(
-            PythonLaunchDescriptionSource([create3_ignition_nodes_launch]),
-            launch_arguments=[('robot_name', LaunchConfiguration('robot_name'))]
+            PythonLaunchDescriptionSource([create3_ignition_nodes_launch])
         ),
 
         # Rviz

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_spawn.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_spawn.launch.py
@@ -3,8 +3,8 @@
 
 from ament_index_python.packages import get_package_share_directory
 
-from irobot_create_common_bringup.offset import OffsetParser, RotationalOffsetX, RotationalOffsetY
 from irobot_create_common_bringup.namespace import GetNamespacedName
+from irobot_create_common_bringup.offset import OffsetParser, RotationalOffsetX, RotationalOffsetY
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, GroupAction

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_spawn.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_spawn.launch.py
@@ -135,7 +135,7 @@ def generate_launch_description():
         IncludeLaunchDescription(
             PythonLaunchDescriptionSource([create3_nodes_launch]),
             launch_arguments=[
-                ('robot_name', robot_name)
+                ('namespace', namespace)
             ]
         ),
 

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_spawn.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_spawn.launch.py
@@ -120,7 +120,7 @@ def generate_launch_description():
         Node(
             package='ros_ign_gazebo',
             executable='create',
-            arguments=['-name', [LaunchConfiguration('robot_name'), '_standard_dock'],
+            arguments=['-name', [LaunchConfiguration('robot_name'), '/standard_dock'],
                        '-x', x_dock,
                        '-y', y,
                        '-z', z,

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_spawn_robot.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/create3_spawn_robot.launch.py
@@ -1,0 +1,156 @@
+# Copyright 2021 Clearpath Robotics, Inc.
+# @author Roni Kreinin (rkreinin@clearpathrobotics.com)
+
+import os
+
+from pathlib import Path
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchContext, LaunchDescription, SomeSubstitutionsType, Substitution
+from launch.actions import DeclareLaunchArgument, GroupAction
+from launch.actions import IncludeLaunchDescription
+from launch.conditions import IfCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node, PushRosNamespace
+
+
+class OffsetParser(Substitution):
+    def __init__(
+            self,
+            number: SomeSubstitutionsType,
+            offset: float,
+    ) -> None:
+        self.__number = number
+        self.__offset = offset
+
+    def perform(
+            self,
+            context: LaunchContext = None,
+    ) -> str:
+        number = float(self.__number.perform(context))
+        return f'{number + self.__offset}'
+
+
+ARGUMENTS = [
+    DeclareLaunchArgument('bridge', default_value='true',
+                          choices=['true', 'false'],
+                          description='Use ros_ign_bridge'),
+    DeclareLaunchArgument('use_sim_time', default_value='true',
+                          choices=['true', 'false'],
+                          description='use_sim_time'),
+    DeclareLaunchArgument('world', default_value='depot',
+                          description='Ignition World'),
+    DeclareLaunchArgument('robot_name', default_value='create3',
+                          description='Robot name'),
+    DeclareLaunchArgument('use_rviz', default_value='true',
+                          choices=['true', 'false'], description='Start rviz.'),
+    DeclareLaunchArgument('spawn_dock', default_value='true',
+                          choices=['true', 'false'],
+                          description='Spawn the standard dock model.'),
+]
+
+for pose_element in ['x', 'y', 'z', 'yaw']:
+    ARGUMENTS.append(DeclareLaunchArgument(pose_element, default_value='0.0',
+                     description=f'{pose_element} component of the robot pose.'))
+
+
+def generate_launch_description():
+
+    # Directories
+    pkg_irobot_create_common_bringup = get_package_share_directory(
+        'irobot_create_common_bringup')
+    pkg_irobot_create_ignition_bringup = get_package_share_directory(
+        'irobot_create_ignition_bringup')
+
+    # Paths
+    ros_ign_bridge_launch = PathJoinSubstitution(
+        [pkg_irobot_create_ignition_bringup, 'launch', 'create3_ros_ignition_bridge.launch.py'])
+    create3_nodes_launch = PathJoinSubstitution(
+        [pkg_irobot_create_common_bringup, 'launch', 'create3_nodes.launch.py'])
+    create3_ignition_nodes_launch = PathJoinSubstitution(
+        [pkg_irobot_create_ignition_bringup, 'launch', 'create3_ignition_nodes.launch.py'])
+    robot_description_launch = PathJoinSubstitution(
+        [pkg_irobot_create_common_bringup, 'launch', 'robot_description.launch.py'])
+    dock_description_launch = PathJoinSubstitution(
+        [pkg_irobot_create_common_bringup, 'launch', 'dock_description.launch.py'])
+
+    # Launch configurations
+    namespace = LaunchConfiguration('robot_name')
+    x, y, z = LaunchConfiguration('x'), LaunchConfiguration('y'), LaunchConfiguration('z')
+    yaw = LaunchConfiguration('yaw')
+
+    x_dock = OffsetParser(x, 0.157)
+    yaw_dock = OffsetParser(yaw, 3.1416)
+
+    spawn_robot_group_action = GroupAction([
+        PushRosNamespace(namespace),
+
+        # Dock description
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([dock_description_launch]),
+            condition=IfCondition(LaunchConfiguration('spawn_dock')),
+            # The robot starts docked
+            launch_arguments={'x': x_dock, 'y': y, 'z': z, 'yaw': yaw_dock,
+                              'namespace': namespace,
+                              'gazebo': 'ignition'}.items(),
+        ),
+
+        # Robot description
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([robot_description_launch]),
+            launch_arguments={'gazebo': 'ignition',
+                              'robot_name': LaunchConfiguration('robot_name')}.items()
+        ),
+
+        # Spawn Create 3
+        Node(
+            package='ros_ign_gazebo',
+            executable='create',
+            arguments=['-name', LaunchConfiguration('robot_name'),
+                       '-x', x,
+                       '-y', y,
+                       '-z', z,
+                       '-Y', '0.0',
+                       '-topic', 'robot_description'],
+            output='screen'
+        ),
+
+        # Spawn dock
+        Node(
+            package='ros_ign_gazebo',
+            executable='create',
+            arguments=['-name', [LaunchConfiguration('robot_name'), '/standard_dock'],
+                       '-x', x_dock,
+                       '-y', y,
+                       '-z', z,
+                       '-Y', '3.141592',
+                       '-topic', 'standard_dock_description'],
+            output='screen',
+        ),
+
+        # ROS Ign Bridge
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([ros_ign_bridge_launch]),
+            launch_arguments=[('world', LaunchConfiguration('world')),
+                              ('robot_name', LaunchConfiguration('robot_name'))]
+        ),
+
+        # Create 3 nodes
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([create3_nodes_launch]),
+            launch_arguments=[('robot_name', LaunchConfiguration('robot_name'))]
+        ),
+
+        # Create 3 Ignition nodes
+        IncludeLaunchDescription(
+            PythonLaunchDescriptionSource([create3_ignition_nodes_launch]),
+            launch_arguments=[('robot_name', LaunchConfiguration('robot_name'))]
+        )
+    ])
+
+    # Create launch description and add actions
+    ld = LaunchDescription(ARGUMENTS)
+    ld.add_action(spawn_robot_group_action)
+    return ld

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/ignition.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/ignition.launch.py
@@ -1,0 +1,105 @@
+# Copyright 2021 Clearpath Robotics, Inc.
+# @author Roni Kreinin (rkreinin@clearpathrobotics.com)
+
+import os
+
+from pathlib import Path
+
+from ament_index_python.packages import get_package_share_directory
+
+from launch import LaunchContext, LaunchDescription, SomeSubstitutionsType, Substitution
+from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node
+
+
+class OffsetParser(Substitution):
+    def __init__(
+            self,
+            number: SomeSubstitutionsType,
+            offset: float,
+    ) -> None:
+        self.__number = number
+        self.__offset = offset
+
+    def perform(
+            self,
+            context: LaunchContext = None,
+    ) -> str:
+        number = float(self.__number.perform(context))
+        return f'{number + self.__offset}'
+
+
+ARGUMENTS = [
+    DeclareLaunchArgument('use_sim_time', default_value='true',
+                          choices=['true', 'false'],
+                          description='use_sim_time'),
+    DeclareLaunchArgument('world', default_value='depot',
+                          description='Ignition World'),
+]
+
+for pose_element in ['x', 'y', 'z', 'yaw']:
+    ARGUMENTS.append(DeclareLaunchArgument(pose_element, default_value='0.0',
+                     description=f'{pose_element} component of the robot pose.'))
+
+
+def generate_launch_description():
+
+    # Directories
+    pkg_irobot_create_ignition_bringup = get_package_share_directory(
+        'irobot_create_ignition_bringup')
+    pkg_irobot_create_ignition_plugins = get_package_share_directory(
+        'irobot_create_ignition_plugins')
+    pkg_irobot_create_description = get_package_share_directory(
+        'irobot_create_description')
+    pkg_ros_ign_gazebo = get_package_share_directory(
+        'ros_ign_gazebo')
+
+    # Set Ignition resource path
+    ign_resource_path = SetEnvironmentVariable(name='IGN_GAZEBO_RESOURCE_PATH',
+                                               value=[os.path.join(
+                                                      pkg_irobot_create_ignition_bringup,
+                                                      'worlds'), ':' +
+                                                      str(Path(
+                                                          pkg_irobot_create_description).
+                                                          parent.resolve())])
+
+    ign_gui_plugin_path = SetEnvironmentVariable(name='IGN_GUI_PLUGIN_PATH',
+                                                 value=[os.path.join(
+                                                        pkg_irobot_create_ignition_plugins,
+                                                        'lib')])
+
+    # Paths
+    ign_gazebo_launch = PathJoinSubstitution(
+        [pkg_ros_ign_gazebo, 'launch', 'ign_gazebo.launch.py'])
+
+    # Ignition gazebo
+    ignition_gazebo = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource([ign_gazebo_launch]),
+        launch_arguments=[
+            ('ign_args', [LaunchConfiguration('world'),
+                          '.sdf',
+                          ' -v 4',
+                          ' --gui-config ',
+                          PathJoinSubstitution([pkg_irobot_create_ignition_bringup,
+                                                'gui', 'create3', 'gui.config'])])
+        ]
+    )
+
+    # clock bridge
+    clock_bridge = Node(package='ros_gz_bridge', executable='parameter_bridge',
+                        name='clock_bridge',
+                        output='screen',
+                        arguments=[
+                            '/clock' + '@rosgraph_msgs/msg/Clock' + '[ignition.msgs.Clock'
+                        ])
+
+    # Create launch description and add actions
+    ld = LaunchDescription(ARGUMENTS)
+    ld.add_action(ign_resource_path)
+    ld.add_action(ign_gui_plugin_path)
+    ld.add_action(ignition_gazebo)
+    ld.add_action(clock_bridge)
+    return ld

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/ignition.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/ignition.launch.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from ament_index_python.packages import get_package_share_directory
 
-from launch import LaunchContext, LaunchDescription, SomeSubstitutionsType, Substitution
+from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable
 from launch.launch_description_sources import PythonLaunchDescriptionSource
@@ -22,10 +22,6 @@ ARGUMENTS = [
     DeclareLaunchArgument('world', default_value='depot',
                           description='Ignition World'),
 ]
-
-for pose_element in ['x', 'y', 'z', 'yaw']:
-    ARGUMENTS.append(DeclareLaunchArgument(pose_element, default_value='0.0',
-                     description=f'{pose_element} component of the robot pose.'))
 
 
 def generate_launch_description():

--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/ignition.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/ignition.launch.py
@@ -15,23 +15,6 @@ from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
 
 
-class OffsetParser(Substitution):
-    def __init__(
-            self,
-            number: SomeSubstitutionsType,
-            offset: float,
-    ) -> None:
-        self.__number = number
-        self.__offset = offset
-
-    def perform(
-            self,
-            context: LaunchContext = None,
-    ) -> str:
-        number = float(self.__number.perform(context))
-        return f'{number + self.__offset}'
-
-
 ARGUMENTS = [
     DeclareLaunchArgument('use_sim_time', default_value='true',
                           choices=['true', 'false'],

--- a/irobot_create_ignition/irobot_create_ignition_bringup/worlds/depot.sdf
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/worlds/depot.sdf
@@ -5,7 +5,7 @@
       <grid>false</grid>
     </scene>
     <physics name="1ms" type="ignored">
-      <max_step_size>0.002</max_step_size>
+      <max_step_size>0.01</max_step_size>
       <real_time_factor>1.0</real_time_factor>
     </physics>
     <plugin filename="ignition-gazebo-physics-system" name="ignition::gazebo::systems::Physics"></plugin>

--- a/irobot_create_ignition/irobot_create_ignition_bringup/worlds/depot.sdf
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/worlds/depot.sdf
@@ -5,12 +5,13 @@
       <grid>false</grid>
     </scene>
     <physics name="1ms" type="ignored">
-      <max_step_size>0.01</max_step_size>
+      <max_step_size>0.003</max_step_size>
       <real_time_factor>1.0</real_time_factor>
     </physics>
     <plugin filename="ignition-gazebo-physics-system" name="ignition::gazebo::systems::Physics"></plugin>
     <plugin filename="ignition-gazebo-user-commands-system" name="ignition::gazebo::systems::UserCommands"></plugin>
     <plugin filename="ignition-gazebo-scene-broadcaster-system" name="ignition::gazebo::systems::SceneBroadcaster"></plugin>
+    <plugin filename="ignition-gazebo-contact-system" name="ignition::gazebo::systems::Contact"></plugin>
 
     <include>
       <uri>

--- a/irobot_create_ignition/irobot_create_ignition_plugins/Create3Hmi/Create3Hmi.cc
+++ b/irobot_create_ignition/irobot_create_ignition_plugins/Create3Hmi/Create3Hmi.cc
@@ -73,7 +73,7 @@ void Create3Hmi::SetName(const QString &_name)
       this->create3_button_topic_ << " ' " <<std::endl;
 
   // Update publisher with new topic.
-  this->create3_button_pub_ = gz::transport::Node::Publisher();
+  this->create3_button_pub_ = ignition::transport::Node::Publisher();
   this->create3_button_pub_ =
       this->node_.Advertise< ignition::msgs::Int32 >
       (this->create3_button_topic_);

--- a/irobot_create_ignition/irobot_create_ignition_plugins/Create3Hmi/Create3Hmi.cc
+++ b/irobot_create_ignition/irobot_create_ignition_plugins/Create3Hmi/Create3Hmi.cc
@@ -71,7 +71,7 @@ void Create3Hmi::SetNamespace(const QString &_name)
 {
   this->namespace_ = _name.toStdString();
   this->create3_button_topic_ = this->namespace_ + "/create3_buttons";
-  
+
   ignmsg << "A new robot name has been entered, publishing on topic: '" <<
       this->create3_button_topic_ << " ' " <<std::endl;
 

--- a/irobot_create_ignition/irobot_create_ignition_plugins/Create3Hmi/Create3Hmi.cc
+++ b/irobot_create_ignition/irobot_create_ignition_plugins/Create3Hmi/Create3Hmi.cc
@@ -5,12 +5,12 @@
 
 #include "Create3Hmi.hh"
 
-#include <iostream>
+#include <ignition/plugin/Register.hh>
+#include <ignition/gui/Application.hh>
+#include <ignition/gui/MainWindow.hh>
+#include <ignition/msgs/int32.pb.h>
 
-#include "ignition/gui/Application.hh"
-#include "ignition/gui/MainWindow.hh"
-#include "ignition/msgs/int32.pb.h"
-#include "ignition/plugin/Register.hh"
+#include <iostream>
 
 namespace ignition
 {
@@ -32,12 +32,15 @@ Create3Hmi::~Create3Hmi()
 
 void Create3Hmi::LoadConfig(const tinyxml2::XMLElement * _pluginElem)
 {
-  if (!_pluginElem) {
-    return;
-  }
-
   if (this->title.empty()) {
     this->title = "Create3 HMI";
+  }
+
+  if (_pluginElem)
+  {
+    auto nameElem = _pluginElem->FirstChildElement("name");
+    if (nullptr != nameElem && nullptr != nameElem->GetText())
+      this->SetName(nameElem->GetText());
   }
 
   this->connect(
@@ -55,6 +58,38 @@ void Create3Hmi::OnCreate3Button(const int button)
     ignerr << "ignition::msgs::Int32 message couldn't be published at topic: " <<
       this->create3_button_topic_ << std::endl;
   }
+}
+
+QString Create3Hmi::Name() const
+{
+  return QString::fromStdString(this->robot_name_);
+}
+
+void Create3Hmi::SetName(const QString &_name)
+{
+  this->robot_name_ = _name.toStdString();
+  this->create3_button_topic_ = "/model/" + this->robot_name_ + "/create3_buttons";
+  ignmsg << "A new robot name has been entered, publishing on topic: '" <<
+      this->create3_button_topic_ << " ' " <<std::endl;
+
+  // Update publisher with new topic.
+  this->create3_button_pub_ = gz::transport::Node::Publisher();
+  this->create3_button_pub_ =
+      this->node_.Advertise< ignition::msgs::Int32 >
+      (this->create3_button_topic_);
+  if (!this->create3_button_pub_)
+  {
+    App()->findChild<MainWindow *>()->notifyWithDuration(
+      QString::fromStdString("Error when advertising topic: " +
+        this->create3_button_topic_), 4000);
+    ignerr << "Error when advertising topic: " <<
+      this->create3_button_topic_ << std::endl;
+  }else {
+    App()->findChild<MainWindow *>()->notifyWithDuration(
+      QString::fromStdString("Advertising topic: '<b>" +
+        this->create3_button_topic_ + "</b>'"), 4000);
+  }
+  this->NameChanged();
 }
 
 }  // namespace gui

--- a/irobot_create_ignition/irobot_create_ignition_plugins/Create3Hmi/Create3Hmi.cc
+++ b/irobot_create_ignition/irobot_create_ignition_plugins/Create3Hmi/Create3Hmi.cc
@@ -5,12 +5,14 @@
 
 #include "Create3Hmi.hh"
 
-#include <ignition/plugin/Register.hh>
-#include <ignition/gui/Application.hh>
-#include <ignition/gui/MainWindow.hh>
 #include <ignition/msgs/int32.pb.h>
 
 #include <iostream>
+
+#include <ignition/plugin/Register.hh>
+#include <ignition/gui/Application.hh>
+#include <ignition/gui/MainWindow.hh>
+
 
 namespace ignition
 {

--- a/irobot_create_ignition/irobot_create_ignition_plugins/Create3Hmi/Create3Hmi.cc
+++ b/irobot_create_ignition/irobot_create_ignition_plugins/Create3Hmi/Create3Hmi.cc
@@ -40,9 +40,9 @@ void Create3Hmi::LoadConfig(const tinyxml2::XMLElement * _pluginElem)
 
   if (_pluginElem)
   {
-    auto nameElem = _pluginElem->FirstChildElement("name");
-    if (nullptr != nameElem && nullptr != nameElem->GetText())
-      this->SetName(nameElem->GetText());
+    auto namespaceElem = _pluginElem->FirstChildElement("namespace");
+    if (nullptr != namespaceElem && nullptr != namespaceElem->GetText())
+      this->SetNamespace(namespaceElem->GetText());
   }
 
   this->connect(
@@ -62,15 +62,16 @@ void Create3Hmi::OnCreate3Button(const int button)
   }
 }
 
-QString Create3Hmi::Name() const
+QString Create3Hmi::Namespace() const
 {
-  return QString::fromStdString(this->robot_name_);
+  return QString::fromStdString(this->namespace_);
 }
 
-void Create3Hmi::SetName(const QString &_name)
+void Create3Hmi::SetNamespace(const QString &_name)
 {
-  this->robot_name_ = _name.toStdString();
-  this->create3_button_topic_ = "/model/" + this->robot_name_ + "/create3_buttons";
+  this->namespace_ = _name.toStdString();
+  this->create3_button_topic_ = this->namespace_ + "/create3_buttons";
+  
   ignmsg << "A new robot name has been entered, publishing on topic: '" <<
       this->create3_button_topic_ << " ' " <<std::endl;
 
@@ -91,7 +92,7 @@ void Create3Hmi::SetName(const QString &_name)
       QString::fromStdString("Advertising topic: '<b>" +
         this->create3_button_topic_ + "</b>'"), 4000);
   }
-  this->NameChanged();
+  this->NamespaceChanged();
 }
 
 }  // namespace gui

--- a/irobot_create_ignition/irobot_create_ignition_plugins/Create3Hmi/Create3Hmi.hh
+++ b/irobot_create_ignition/irobot_create_ignition_plugins/Create3Hmi/Create3Hmi.hh
@@ -6,12 +6,13 @@
 #ifndef IROBOT_CREATE_IGNITION__IROBOT_CREATE_IGNITION_PLUGINS__CREATE3HMI__CREATE3HMI_HH_
 #define IROBOT_CREATE_IGNITION__IROBOT_CREATE_IGNITION_PLUGINS__CREATE3HMI__CREATE3HMI_HH_
 
-#include <ignition/transport/Node.hh>
-
 #include <ignition/gui/qt.h>
-#include <ignition/gui/Plugin.hh>
 
 #include <string>
+
+#include <ignition/gui/Plugin.hh>
+#include <ignition/transport/Node.hh>
+
 
 namespace ignition
 {

--- a/irobot_create_ignition/irobot_create_ignition_plugins/Create3Hmi/Create3Hmi.hh
+++ b/irobot_create_ignition/irobot_create_ignition_plugins/Create3Hmi/Create3Hmi.hh
@@ -27,9 +27,9 @@ class Create3Hmi : public Plugin
   // \brief Name
   Q_PROPERTY(
     QString name
-    READ Name
-    WRITE SetName
-    NOTIFY NameChanged
+    READ Namespace
+    WRITE SetNamespace
+    NOTIFY NamespaceChanged
   )
 
 public:
@@ -43,17 +43,17 @@ public:
   // \brief Get the robot name as a string, for example
   /// '/echo'
   /// \return Name
-  Q_INVOKABLE QString Name() const;
+  Q_INVOKABLE QString Namespace() const;
 
 public slots:
   /// \brief Callback in Qt thread when the robot name changes.
   /// \param[in] _name variable to indicate the robot name to
   /// publish the Button commands.
-  void SetName(const QString &_name);
+  void SetNamespace(const QString &_name);
 
 signals:
   /// \brief Notify that robot name has changed
-  void NameChanged();
+  void NamespaceChanged();
 
 protected slots:
   /// \brief Callback trigged when the button is pressed.
@@ -62,8 +62,8 @@ protected slots:
 private:
   ignition::transport::Node node_;
   ignition::transport::Node::Publisher create3_button_pub_;
-  std::string robot_name_ = "create3";
-  std::string create3_button_topic_ = "/model/create3/create3_buttons";
+  std::string namespace_ = "";
+  std::string create3_button_topic_ = "/create3_buttons";
 };
 
 }  // namespace gui

--- a/irobot_create_ignition/irobot_create_ignition_plugins/Create3Hmi/Create3Hmi.hh
+++ b/irobot_create_ignition/irobot_create_ignition_plugins/Create3Hmi/Create3Hmi.hh
@@ -6,12 +6,12 @@
 #ifndef IROBOT_CREATE_IGNITION__IROBOT_CREATE_IGNITION_PLUGINS__CREATE3HMI__CREATE3HMI_HH_
 #define IROBOT_CREATE_IGNITION__IROBOT_CREATE_IGNITION_PLUGINS__CREATE3HMI__CREATE3HMI_HH_
 
+#include <ignition/transport/Node.hh>
+
+#include <ignition/gui/qt.h>
+#include <ignition/gui/Plugin.hh>
 
 #include <string>
-
-#include "ignition/gui/qt.h"
-#include "ignition/gui/Plugin.hh"
-#include "ignition/transport/Node.hh"
 
 namespace ignition
 {
@@ -23,6 +23,14 @@ class Create3Hmi : public Plugin
 {
   Q_OBJECT
 
+  // \brief Name
+  Q_PROPERTY(
+    QString name
+    READ Name
+    WRITE SetName
+    NOTIFY NameChanged
+  )
+
 public:
   /// \brief Constructor
   Create3Hmi();
@@ -31,14 +39,30 @@ public:
   /// \brief Called by Ignition GUI when plugin is instantiated.
   /// \param[in] _pluginElem XML configuration for this plugin.
   void LoadConfig(const tinyxml2::XMLElement *_pluginElem) override;
+  // \brief Get the robot name as a string, for example
+  /// '/echo'
+  /// \return Name
+  Q_INVOKABLE QString Name() const;
+
+public slots:
+  /// \brief Callback in Qt thread when the robot name changes.
+  /// \param[in] _name variable to indicate the robot name to
+  /// publish the Button commands.
+  void SetName(const QString &_name);
+
+signals:
+  /// \brief Notify that robot name has changed
+  void NameChanged();
 
 protected slots:
   /// \brief Callback trigged when the button is pressed.
   void OnCreate3Button(const int button);
+
 private:
   ignition::transport::Node node_;
   ignition::transport::Node::Publisher create3_button_pub_;
-  std::string create3_button_topic_ = "/create3/buttons";
+  std::string robot_name_ = "create3";
+  std::string create3_button_topic_ = "/model/create3/create3_buttons";
 };
 
 }  // namespace gui

--- a/irobot_create_ignition/irobot_create_ignition_plugins/Create3Hmi/Create3Hmi.qml
+++ b/irobot_create_ignition/irobot_create_ignition_plugins/Create3Hmi/Create3Hmi.qml
@@ -29,10 +29,10 @@ Rectangle
     height: 175
     width: 400
 
-    // Robot Name input
+    // Robot namespace input
     Label {
-      id: nameLabel
-      text: "Robot Name:"
+      id: namespaceLabel
+      text: "Namespace:"
       Layout.fillWidth: true
       Layout.margins: 10
       anchors.top: create3ButtonsRectangle.top
@@ -46,14 +46,14 @@ Rectangle
       width: 175
       Layout.fillWidth: true
       Layout.margins: 10
-      text: Create3Hmi.name
-      placeholderText: qsTr("input robot name")
-      anchors.top: nameLabel.bottom
+      text: Create3Hmi.namespace
+      placeholderText: qsTr("Robot namespace")
+      anchors.top: namespaceLabel.bottom
       anchors.topMargin: 5
       anchors.left: create3ButtonsRectangle.left
       anchors.leftMargin: 10
       onEditingFinished: {
-        Create3Hmi.SetName(text)
+        Create3Hmi.SetNamespace(text)
       }
     }
 

--- a/irobot_create_ignition/irobot_create_ignition_plugins/Create3Hmi/Create3Hmi.qml
+++ b/irobot_create_ignition/irobot_create_ignition_plugins/Create3Hmi/Create3Hmi.qml
@@ -17,30 +17,47 @@ Rectangle
   anchors.fill: parent
   focus: true
   Layout.minimumWidth: 400
-  Layout.minimumHeight: 175
+  Layout.minimumHeight: 225
 
   Rectangle
   {
     id: create3ButtonsRectangle
-    border.color: "black"
     border.width: 2
     anchors.top: widgetRectangle.top
     anchors.left: widgetRectangle.left
     focus: true
-    height: 125
+    height: 175
     width: 400
 
-    // Buttons
+    // Robot Name input
     Label {
-      id: create3ButtonsLabel
-      text: "Create3"
-      font.pixelSize: 22
+      id: nameLabel
+      text: "Robot Name:"
+      Layout.fillWidth: true
+      Layout.margins: 10
       anchors.top: create3ButtonsRectangle.top
       anchors.topMargin: 10
-      anchors.left: parent.left
+      anchors.left: create3ButtonsRectangle.left
       anchors.leftMargin: 10
     }
 
+    TextField {
+      id: nameField
+      width: 175
+      Layout.fillWidth: true
+      Layout.margins: 10
+      text: Create3Hmi.name
+      placeholderText: qsTr("input robot name")
+      anchors.top: nameLabel.bottom
+      anchors.topMargin: 5
+      anchors.left: create3ButtonsRectangle.left
+      anchors.leftMargin: 10
+      onEditingFinished: {
+        Create3Hmi.SetName(text)
+      }
+    }
+
+    // Button inputs
     ToolButton {
       id: create3Button1
       anchors.verticalCenter: create3ButtonPower.verticalCenter
@@ -62,8 +79,8 @@ Rectangle
 
     ToolButton {
       id: create3ButtonPower
-      anchors.top: create3ButtonsLabel.bottom
-      anchors.topMargin: 0
+      anchors.bottom: create3ButtonsRectangle.bottom
+      anchors.bottomMargin: 15
       anchors.horizontalCenter: create3ButtonsRectangle.horizontalCenter
       checkable: true
       checked: true
@@ -99,4 +116,3 @@ Rectangle
     }
   }
 }
-

--- a/irobot_create_ignition/irobot_create_ignition_toolbox/include/irobot_create_ignition_toolbox/pose_republisher/pose_republisher.hpp
+++ b/irobot_create_ignition/irobot_create_ignition_toolbox/include/irobot_create_ignition_toolbox/pose_republisher/pose_republisher.hpp
@@ -46,8 +46,8 @@ private:
   tf2::Transform last_dock_pose_;
 
   std::string robot_name_;
+  std::string dock_name_;
   std::string wheel_joints_[2];
-  std::string standard_dock_frame_id_;
 };
 
 }  // namespace irobot_create_ignition_toolbox

--- a/irobot_create_ignition/irobot_create_ignition_toolbox/include/irobot_create_ignition_toolbox/pose_republisher/pose_republisher.hpp
+++ b/irobot_create_ignition/irobot_create_ignition_toolbox/include/irobot_create_ignition_toolbox/pose_republisher/pose_republisher.hpp
@@ -47,6 +47,7 @@ private:
 
   std::string robot_name_;
   std::string wheel_joints_[2];
+  std::string standard_dock_frame_id_;
 };
 
 }  // namespace irobot_create_ignition_toolbox

--- a/irobot_create_ignition/irobot_create_ignition_toolbox/include/irobot_create_ignition_toolbox/sensors/bumper.hpp
+++ b/irobot_create_ignition/irobot_create_ignition_toolbox/include/irobot_create_ignition_toolbox/sensors/bumper.hpp
@@ -14,7 +14,7 @@
 #include "irobot_create_msgs/msg/hazard_detection.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include "ros_ign_interfaces/msg/contacts.hpp"
+#include "ros_gz_interfaces/msg/contacts.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 namespace irobot_create_ignition_toolbox
@@ -27,12 +27,12 @@ public:
   virtual ~Bumper() {}
 
 private:
-  void bumper_callback(const ros_ign_interfaces::msg::Contacts::SharedPtr bumper_contact_msg);
+  void bumper_callback(const ros_gz_interfaces::msg::Contacts::SharedPtr bumper_contact_msg);
   void robot_pose_callback(nav_msgs::msg::Odometry::ConstSharedPtr msg);
 
   std::shared_ptr<rclcpp::Node> nh_;
 
-  rclcpp::Subscription<ros_ign_interfaces::msg::Contacts>::SharedPtr bumper_sub_;
+  rclcpp::Subscription<ros_gz_interfaces::msg::Contacts>::SharedPtr bumper_sub_;
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr robot_pose_sub_;
   rclcpp::Publisher<irobot_create_msgs::msg::HazardDetection>::SharedPtr hazard_pub_;
 

--- a/irobot_create_ignition/irobot_create_ignition_toolbox/src/interface_buttons/interface_buttons_node.cpp
+++ b/irobot_create_ignition/irobot_create_ignition_toolbox/src/interface_buttons/interface_buttons_node.cpp
@@ -12,7 +12,7 @@ InterfaceButtons::InterfaceButtons()
 : rclcpp::Node("sensors_node")
 {
   interface_buttons_sub_ = this->create_subscription<std_msgs::msg::Int32>(
-    "create3/buttons",
+    "create3_buttons",
     rclcpp::SensorDataQoS(),
     std::bind(&InterfaceButtons::create3_buttons_callback, this, std::placeholders::_1));
 

--- a/irobot_create_ignition/irobot_create_ignition_toolbox/src/interface_buttons/interface_buttons_node.cpp
+++ b/irobot_create_ignition/irobot_create_ignition_toolbox/src/interface_buttons/interface_buttons_node.cpp
@@ -12,7 +12,7 @@ InterfaceButtons::InterfaceButtons()
 : rclcpp::Node("sensors_node")
 {
   interface_buttons_sub_ = this->create_subscription<std_msgs::msg::Int32>(
-    "create3_buttons",
+    "_create3_buttons",
     rclcpp::SensorDataQoS(),
     std::bind(&InterfaceButtons::create3_buttons_callback, this, std::placeholders::_1));
 

--- a/irobot_create_ignition/irobot_create_ignition_toolbox/src/interface_buttons/interface_buttons_node.cpp
+++ b/irobot_create_ignition/irobot_create_ignition_toolbox/src/interface_buttons/interface_buttons_node.cpp
@@ -12,7 +12,7 @@ InterfaceButtons::InterfaceButtons()
 : rclcpp::Node("sensors_node")
 {
   interface_buttons_sub_ = this->create_subscription<std_msgs::msg::Int32>(
-    "_create3_buttons",
+    "_internal/create3_buttons",
     rclcpp::SensorDataQoS(),
     std::bind(&InterfaceButtons::create3_buttons_callback, this, std::placeholders::_1));
 

--- a/irobot_create_ignition/irobot_create_ignition_toolbox/src/pose_republisher/pose_republisher_node.cpp
+++ b/irobot_create_ignition/irobot_create_ignition_toolbox/src/pose_republisher/pose_republisher_node.cpp
@@ -75,7 +75,7 @@ PoseRepublisher::PoseRepublisher()
   // Standard dock frame id is namespaced
   standard_dock_frame_id_ = get_effective_namespace() + "/standard_dock";
   // Remove leading '/'
-  standard_dock_frame_id_.erase(0, 1); 
+  standard_dock_frame_id_.erase(0, 1);
 }
 
 void PoseRepublisher::robot_subscriber_callback(const tf2_msgs::msg::TFMessage::SharedPtr msg)
@@ -119,7 +119,6 @@ void PoseRepublisher::robot_subscriber_callback(const tf2_msgs::msg::TFMessage::
 
 void PoseRepublisher::dock_subscriber_callback(const tf2_msgs::msg::TFMessage::SharedPtr msg)
 {
-  
   for (uint16_t i = 0; i < msg->transforms.size(); i++) {
     // Child frame is model name
     if (msg->transforms[i].child_frame_id == standard_dock_frame_id_) {

--- a/irobot_create_ignition/irobot_create_ignition_toolbox/src/pose_republisher/pose_republisher_node.cpp
+++ b/irobot_create_ignition/irobot_create_ignition_toolbox/src/pose_republisher/pose_republisher_node.cpp
@@ -72,10 +72,8 @@ PoseRepublisher::PoseRepublisher()
     "dynamic_joint_states",
     rclcpp::SystemDefaultsQoS());
 
-  // Standard dock frame id is namespaced
-  standard_dock_frame_id_ = get_effective_namespace() + "/standard_dock";
-  // Remove leading '/'
-  standard_dock_frame_id_.erase(0, 1);
+  // Standard dock frame id
+  standard_dock_frame_id_ = robot_name_ + "/standard_dock";
 }
 
 void PoseRepublisher::robot_subscriber_callback(const tf2_msgs::msg::TFMessage::SharedPtr msg)

--- a/irobot_create_ignition/irobot_create_ignition_toolbox/src/pose_republisher/pose_republisher_node.cpp
+++ b/irobot_create_ignition/irobot_create_ignition_toolbox/src/pose_republisher/pose_republisher_node.cpp
@@ -119,6 +119,7 @@ void PoseRepublisher::robot_subscriber_callback(const tf2_msgs::msg::TFMessage::
 
 void PoseRepublisher::dock_subscriber_callback(const tf2_msgs::msg::TFMessage::SharedPtr msg)
 {
+  
   for (uint16_t i = 0; i < msg->transforms.size(); i++) {
     // Child frame is model name
     if (msg->transforms[i].child_frame_id == standard_dock_frame_id_) {

--- a/irobot_create_ignition/irobot_create_ignition_toolbox/src/pose_republisher/pose_republisher_node.cpp
+++ b/irobot_create_ignition/irobot_create_ignition_toolbox/src/pose_republisher/pose_republisher_node.cpp
@@ -17,6 +17,8 @@ PoseRepublisher::PoseRepublisher()
 {
   robot_name_ =
     this->declare_parameter("robot_name", "create3");
+  dock_name_ =
+    this->declare_parameter("dock_name", "standard_dock");
   std::string robot_pub_topic =
     this->declare_parameter("robot_publisher_topic", "sim_ground_truth_pose");
   std::string robot_sub_topic =
@@ -71,9 +73,6 @@ PoseRepublisher::PoseRepublisher()
   dynamic_joint_state_publisher_ = create_publisher<control_msgs::msg::DynamicJointState>(
     "dynamic_joint_states",
     rclcpp::SystemDefaultsQoS());
-
-  // Standard dock frame id
-  standard_dock_frame_id_ = robot_name_ + "/standard_dock";
 }
 
 void PoseRepublisher::robot_subscriber_callback(const tf2_msgs::msg::TFMessage::SharedPtr msg)
@@ -119,7 +118,7 @@ void PoseRepublisher::dock_subscriber_callback(const tf2_msgs::msg::TFMessage::S
 {
   for (uint16_t i = 0; i < msg->transforms.size(); i++) {
     // Child frame is model name
-    if (msg->transforms[i].child_frame_id == standard_dock_frame_id_) {
+    if (msg->transforms[i].child_frame_id == dock_name_) {
       auto odom_msg = utils::tf_message_to_odom(msg, i);
       // Save dock pose
       tf2::convert(odom_msg->pose.pose, last_dock_pose_);

--- a/irobot_create_ignition/irobot_create_ignition_toolbox/src/pose_republisher/pose_republisher_node.cpp
+++ b/irobot_create_ignition/irobot_create_ignition_toolbox/src/pose_republisher/pose_republisher_node.cpp
@@ -18,20 +18,20 @@ PoseRepublisher::PoseRepublisher()
   robot_name_ =
     this->declare_parameter("robot_name", "create3");
   std::string robot_pub_topic =
-    this->declare_parameter("robot_publisher_topic", "/sim_ground_truth_pose");
+    this->declare_parameter("robot_publisher_topic", "sim_ground_truth_pose");
   std::string robot_sub_topic =
-    this->declare_parameter("robot_subscriber_topic", "/sim_ground_truth_pose");
+    this->declare_parameter("robot_subscriber_topic", "sim_ground_truth_pose");
   std::string mouse_pub_topic =
-    this->declare_parameter("mouse_publisher_topic", "/sim_ground_truth_mouse_pose");
+    this->declare_parameter("mouse_publisher_topic", "sim_ground_truth_mouse_pose");
 
   std::string dock_pub_topic =
-    this->declare_parameter("dock_publisher_topic", "/sim_ground_truth_dock_pose");
+    this->declare_parameter("dock_publisher_topic", "sim_ground_truth_dock_pose");
   std::string dock_sub_topic =
-    this->declare_parameter("dock_subscriber_topic", "/sim_ground_truth_dock_pose");
+    this->declare_parameter("dock_subscriber_topic", "sim_ground_truth_dock_pose");
   std::string ir_emitter_pub_topic =
-    this->declare_parameter("ir_emitter_publisher_topic", "/sim_ground_truth_ir_emitter_pose");
+    this->declare_parameter("ir_emitter_publisher_topic", "sim_ground_truth_ir_emitter_pose");
   std::string ir_receiver_pub_topic =
-    this->declare_parameter("ir_receiver_publisher_topic", "/sim_ground_truth_ir_receiver_pose");
+    this->declare_parameter("ir_receiver_publisher_topic", "sim_ground_truth_ir_receiver_pose");
 
   robot_subscriber_ = create_subscription<tf2_msgs::msg::TFMessage>(
     robot_sub_topic,

--- a/irobot_create_ignition/irobot_create_ignition_toolbox/src/pose_republisher/pose_republisher_node.cpp
+++ b/irobot_create_ignition/irobot_create_ignition_toolbox/src/pose_republisher/pose_republisher_node.cpp
@@ -71,6 +71,11 @@ PoseRepublisher::PoseRepublisher()
   dynamic_joint_state_publisher_ = create_publisher<control_msgs::msg::DynamicJointState>(
     "dynamic_joint_states",
     rclcpp::SystemDefaultsQoS());
+
+  // Standard dock frame id is namespaced
+  standard_dock_frame_id_ = get_effective_namespace() + "/standard_dock";
+  // Remove leading '/'
+  standard_dock_frame_id_.erase(0, 1); 
 }
 
 void PoseRepublisher::robot_subscriber_callback(const tf2_msgs::msg::TFMessage::SharedPtr msg)
@@ -116,7 +121,7 @@ void PoseRepublisher::dock_subscriber_callback(const tf2_msgs::msg::TFMessage::S
 {
   for (uint16_t i = 0; i < msg->transforms.size(); i++) {
     // Child frame is model name
-    if (msg->transforms[i].child_frame_id == "standard_dock") {
+    if (msg->transforms[i].child_frame_id == standard_dock_frame_id_) {
       auto odom_msg = utils::tf_message_to_odom(msg, i);
       // Save dock pose
       tf2::convert(odom_msg->pose.pose, last_dock_pose_);

--- a/irobot_create_ignition/irobot_create_ignition_toolbox/src/sensors/bumper.cpp
+++ b/irobot_create_ignition/irobot_create_ignition_toolbox/src/sensors/bumper.cpp
@@ -17,7 +17,7 @@ using irobot_create_ignition_toolbox::Bumper;
 Bumper::Bumper(std::shared_ptr<rclcpp::Node> & nh)
 : nh_(nh)
 {
-  bumper_sub_ = nh_->create_subscription<ros_ign_interfaces::msg::Contacts>(
+  bumper_sub_ = nh_->create_subscription<ros_gz_interfaces::msg::Contacts>(
     "bumper_contact",
     rclcpp::SensorDataQoS(),
     std::bind(&Bumper::bumper_callback, this, std::placeholders::_1));
@@ -31,7 +31,7 @@ Bumper::Bumper(std::shared_ptr<rclcpp::Node> & nh)
     "_internal/bumper/event", rclcpp::SensorDataQoS());
 }
 
-void Bumper::bumper_callback(const ros_ign_interfaces::msg::Contacts::SharedPtr bumper_contact_msg)
+void Bumper::bumper_callback(const ros_gz_interfaces::msg::Contacts::SharedPtr bumper_contact_msg)
 {
   tf2::Transform robot_pose(tf2::Transform::getIdentity());
   {

--- a/irobot_create_ignition/irobot_create_ignition_toolbox/src/sensors/ir_opcode.cpp
+++ b/irobot_create_ignition/irobot_create_ignition_toolbox/src/sensors/ir_opcode.cpp
@@ -15,12 +15,12 @@ IrOpcode::IrOpcode(std::shared_ptr<rclcpp::Node> & nh)
 : nh_(nh)
 {
   emitter_pose_sub_ = nh_->create_subscription<nav_msgs::msg::Odometry>(
-    "/_internal/sim_ground_truth_ir_emitter_pose",
+    "_internal/sim_ground_truth_ir_emitter_pose",
     rclcpp::SensorDataQoS(),
     std::bind(&IrOpcode::emitter_pose_callback, this, std::placeholders::_1));
 
   receiver_pose_sub_ = nh_->create_subscription<nav_msgs::msg::Odometry>(
-    "/_internal/sim_ground_truth_ir_receiver_pose",
+    "_internal/sim_ground_truth_ir_receiver_pose",
     rclcpp::SensorDataQoS(),
     std::bind(&IrOpcode::receiver_pose_callback, this, std::placeholders::_1));
 

--- a/irobot_create_ignition/irobot_create_ignition_toolbox/src/sensors/mouse.cpp
+++ b/irobot_create_ignition/irobot_create_ignition_toolbox/src/sensors/mouse.cpp
@@ -16,7 +16,7 @@ Mouse::Mouse(std::shared_ptr<rclcpp::Node> & nh)
   last_mouse_position_{0, 0, 0}
 {
   mouse_pose_sub_ = nh_->create_subscription<nav_msgs::msg::Odometry>(
-    "/_internal/sim_ground_truth_mouse_pose",
+    "_internal/sim_ground_truth_mouse_pose",
     rclcpp::SensorDataQoS(),
     std::bind(&Mouse::mouse_pose_callback, this, std::placeholders::_1));
 


### PR DESCRIPTION
## Description

Alternative to #189, but using `GroupAction` and `PushRosNamespace` for a cleaner implementation.
I am also proposing that the namespace is the robot name, and by default all robots will have to be namespaced for consistency, even with just 1 robot. The default robot name and therefore namespace is `create3`.

Launch files updates (ignition):
- `ignition.launch.py`: Launches just Gazebo without spawning a robot
- `create3_spawn.launch.py`: Spawns a robot. Requires that `ignition.launch.py` has been launched first.
- `create3_ignition.launch.py`: Default launch file to launch `ignition.launch.py` with a default `create3` robot.

Other changes:
- cmd_vel: 
  - In ignition, `/<namespace>/cmd_vel` is now the topic being bridged to the equivalent `/<namespace>/cmd_vel` ros topic.
  - Default `cmd_vel` topic for teleop plugin is now `/create3/cmd_vel`.
- Create3 buttons:
  - Ignition topic is now `/model/<namespace>/create3_buttons`. ROS topic is now `/<namespace>/_create3_buttons`. Its hidden so that it is not confused with `interface_buttons`.
- Using `ros_gz_bridge` instead of `ros_ign_bridge`. The `ign` version was not being terminated properly when the simulation was closed, leaving stray nodes running in the background.
- Created individual bridges for each lidar. Supposed to increase performance. See https://github.com/gazebosim/ros_gz/issues/368
- Added static transforms from tf_prefixed odom and base_link frames to namespaced frames. See https://github.com/ros-controls/ros2_controllers/pull/533
- Spawning dock correctly when the `y` and `yaw` values are changed.
- Open a namespaced RViz window for each robot

TODO:
- [x] Fix docking status
- [x] Update RViz config
- [ ] Add the same changes to classic gazebo
- [x] Get https://github.com/ros-controls/gz_ros2_control/pull/92 merged and released.

Notes:
- Spawning 2 robots works, but spawning a 3rd causes a libGL segfault for me. Not sure if this is a hardware limitation.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Also list any relevant details for your test configuration.

```bash
# Default single robot launch
ros2 launch irobot_create_ignition_bringup create3_ignition.launch.py

# Spawn a second robot
ros2 launch irobot_create_ignition_bringup create3_spawn.launch.py namespace:=robot2 y:=1.0
```

Alternatively:
```bash
# Launch ignition
ros2 launch irobot_create_ignition_bringup ignition.launch.py

# Spawn robot 1
ros2 launch irobot_create_ignition_bringup create3_spawn.launch.py namespace:=robot1 

# Spawn robot 2
ros2 launch irobot_create_ignition_bringup create3_spawn.launch.py namespace:=robot2 y:=1.0
```

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
