### PR TITLE
add workflow_dispatch label to CI to allow for manual triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build_and_test:


### PR DESCRIPTION
## Description

add workflow_dispatch label to CI to allow for manual triggers

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

