### PR TITLE
Add dependencies to `irobot_create_common`

### DIFF
--- a/irobot_create_common/irobot_create_description/package.xml
+++ b/irobot_create_common/irobot_create_description/package.xml
@@ -11,7 +11,9 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <exec_depend>irobot_create_control</exec_depend>
   <exec_depend>urdf</exec_depend>
+  <exec_depend>xacro</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_cmake_lint_cmake</test_depend>


### PR DESCRIPTION
## Description

Adds `irobot_create_description`'s dependency to `irobot_create_control`.  PR #171 was already merged but somehow this was reverted.

Fixes # (issue).

`package not found: "package 'irobot_create_control' not found, searching: ['/opt/ros/humble']"`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Cf. #171.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
