### PR TITLE
Wheel Ticks calculation code equation correction

### DIFF
--- a/irobot_create_common/irobot_create_nodes/include/irobot_create_nodes/wheels_publisher.hpp
+++ b/irobot_create_common/irobot_create_nodes/include/irobot_create_nodes/wheels_publisher.hpp
@@ -35,7 +35,6 @@ private:
 
   // Encoder parameters
   double encoder_resolution_;
-  double wheel_circumference_;
 
   // Handling wheel ticks and wheel velocity messages
   rclcpp::TimerBase::SharedPtr timer_;

--- a/irobot_create_common/irobot_create_nodes/src/wheels_publisher.cpp
+++ b/irobot_create_common/irobot_create_nodes/src/wheels_publisher.cpp
@@ -30,12 +30,6 @@ WheelsPublisher::WheelsPublisher(const rclcpp::NodeOptions & options)
   encoder_resolution_ =
     this->declare_parameter("encoder_resolution", 508.8);
 
-  // wheel radius in meters
-  const double wheel_radius =
-    this->declare_parameter("wheel_radius", 0.03575);
-  // Set wheel circumference from wheel radius parameter
-  wheel_circumference_ = 2 * M_PI * wheel_radius;
-
   angular_vels_publisher_ = create_publisher<irobot_create_msgs::msg::WheelVels>(
     velocity_topic, rclcpp::SystemDefaultsQoS());
   RCLCPP_INFO_STREAM(get_logger(), "Advertised topic: " << velocity_topic);

--- a/irobot_create_common/irobot_create_nodes/src/wheels_publisher.cpp
+++ b/irobot_create_common/irobot_create_nodes/src/wheels_publisher.cpp
@@ -76,10 +76,10 @@ void WheelsPublisher::publisher_callback()
 
     // Calculate and write WheelTicks msg
     const double left_ticks =
-      (get_dynamic_state_value("left_wheel_joint", "position") / wheel_circumference_) *
+      (get_dynamic_state_value("left_wheel_joint", "position") / (2 * M_PI)) *
       encoder_resolution_;
     const double right_ticks =
-      (get_dynamic_state_value("right_wheel_joint", "position") / wheel_circumference_) *
+      (get_dynamic_state_value("right_wheel_joint", "position") / (2 * M_PI)) *
       encoder_resolution_;
 
     wheel_ticks_msg_.ticks_left = std::round(left_ticks);


### PR DESCRIPTION
## Description

I am trying to create my own odometry filter and I was using the simulation when I noticed that the ticks values were wrong.

In the code, file `irobot_create_nodes\src\wheels_publisher.cpp`, lines 79 and 82:

$$
\text{Ticks}_L = \frac{\theta_L}{2  \pi  r} \times 508.8~~~~ \text{Ticks}_R = \frac{\theta_R}{2  \pi  r} \times 508.8
$$ 


The correct formula is:

$$
\text{Ticks}_L = \frac{\theta_L}{2  \pi} \times 508.8~~~~ \text{Ticks}_R = \frac{\theta_R}{2  \pi} \times 508.8
$$

Without the $r$...

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I ran the simulation and compared the wheels rotation reported by the `dynamic_joint_states` topic and the wheels rotation calculated by the formula:

$$
\theta_{L|R} = \frac{\text{Ticks}_{L|R}}{508.8} \times 2\pi
$$

```bash
# Run this command (Gazebo)
ros2 launch irobot_create_gazebo_bringup create3_gazebo.launch.py 

# Or (Ignition)
ros2 launch irobot_create_ignition_bringup create3_ignition.launch.py 
```

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas **(No need)**
- [ ] I have made corresponding changes to the documentation **(No need)**
