### PR TITLE
Replaced SetEnvironmentVariable with AppendEnvironmentVariable in ignition.launch.py

### DIFF
--- a/irobot_create_ignition/irobot_create_ignition_bringup/launch/ignition.launch.py
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/launch/ignition.launch.py
@@ -9,7 +9,7 @@ from ament_index_python.packages import get_package_share_directory
 
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
-from launch.actions import IncludeLaunchDescription, SetEnvironmentVariable
+from launch.actions import IncludeLaunchDescription, AppendEnvironmentVariable
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
 from launch_ros.actions import Node
@@ -37,7 +37,7 @@ def generate_launch_description():
         'ros_ign_gazebo')
 
     # Set Ignition resource path
-    ign_resource_path = SetEnvironmentVariable(name='IGN_GAZEBO_RESOURCE_PATH',
+    ign_resource_path = AppendEnvironmentVariable(name='IGN_GAZEBO_RESOURCE_PATH',
                                                value=[os.path.join(
                                                       pkg_irobot_create_ignition_bringup,
                                                       'worlds'), ':' +
@@ -45,7 +45,7 @@ def generate_launch_description():
                                                           pkg_irobot_create_description).
                                                           parent.resolve())])
 
-    ign_gui_plugin_path = SetEnvironmentVariable(name='IGN_GUI_PLUGIN_PATH',
+    ign_gui_plugin_path = AppendEnvironmentVariable(name='IGN_GUI_PLUGIN_PATH',
                                                  value=[os.path.join(
                                                         pkg_irobot_create_ignition_plugins,
                                                         'lib')])


### PR DESCRIPTION
## Description

I discovered that if anyone had set up an environment variable such as IGN_GAZEBO_RESOURCE_PATH and GN_GAZEBO_PLUGIN_PATH, the launcher overwrote them with new path.
To fix this problem, I replaced `SetEnvironmentVariable` with `AppendEnvironmentVariable` in this way if the variables already existed, the launcher will append new paths otherwise it will create them.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I discovered this problem when I was trying to spawn a x500 of PX4 in the world with Gazebo Garden (I forked the code and I am making the porting from Ignition to Gazebo garden) but the same problem there is also in the ignition launcher.
Possible way to test it:
- export IGN_GAZEBO_RESOURCE_PATH:=\<custom model folder\>
- ros2 launch irobot_create_ignition_bringup create3_ignition.launch.py 
- spawn the custom model 

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
