### PR TITLE
replace gz-gui8 with gz_gui_vendor

### DIFF
--- a/irobot_create_gz/irobot_create_gz_plugins/package.xml
+++ b/irobot_create_gz/irobot_create_gz_plugins/package.xml
@@ -9,7 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>gz-gui8</depend>
+  <depend>gz_gui_vendor</depend>
   <depend>ros_gz</depend>
 
   <test_depend>ament_lint_auto</test_depend>


### PR DESCRIPTION
back to what was used before, but as depend rather than buildtool_depend
