### PR TITLE
Generalize gz vendor use and modernize CMake

### DIFF
--- a/irobot_create_common/irobot_create_toolbox/CMakeLists.txt
+++ b/irobot_create_common/irobot_create_toolbox/CMakeLists.txt
@@ -11,15 +11,11 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
-find_package(gz-math7 REQUIRED)
+find_package(gz_math_vendor REQUIRED)
+find_package(gz-math REQUIRED)
 find_package(rclcpp REQUIRED)
 
 #### Libraries
-
-set(dependencies
-  gz-math7
-  rclcpp
-)
 
 add_library(irobot_create_toolbox SHARED)
 target_sources(
@@ -27,26 +23,34 @@ target_sources(
   PRIVATE
     src/polar_coordinates.cpp
 )
-target_include_directories(irobot_create_toolbox PUBLIC include)
-ament_target_dependencies(irobot_create_toolbox
-  ${dependencies}
+target_include_directories(irobot_create_toolbox PUBLIC
+ "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+ "$<INSTALL_INTERFACE:include/${PROJECT_NAME}>")
+
+target_link_libraries(irobot_create_toolbox
+  PUBLIC
+    gz-math::gz-math
+    ${rclcpp_TARGETS}
 )
 
 #### Install
 
-install(TARGETS irobot_create_toolbox
+install(TARGETS
+  ${PROJECT_NAME} EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   RUNTIME DESTINATION bin
 )
 
 install(DIRECTORY include/
-  DESTINATION include
+  DESTINATION include/${PROJECT_NAME}
 )
-
-ament_export_include_directories(include)
-ament_export_libraries(irobot_create_toolbox)
-ament_export_dependencies(${dependencies})
+ament_export_targets(export_${PROJECT_NAME})
+ament_export_dependencies(
+  gz_math_vendor
+  gz-math
+  rclcpp
+)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/irobot_create_gz/irobot_create_gz_plugins/CMakeLists.txt
+++ b/irobot_create_gz/irobot_create_gz_plugins/CMakeLists.txt
@@ -11,7 +11,7 @@ find_package(ament_cmake REQUIRED)
 set(OpenGL_GL_PREFERENCE LEGACY)
 
 # Find the Ignition gui library
-find_package(gz-gui8 REQUIRED)
+find_package(gz_gui_vendor REQUIRED)
 add_subdirectory(Create3Hmi)
 
 if(BUILD_TESTING)

--- a/irobot_create_gz/irobot_create_gz_plugins/Create3Hmi/CMakeLists.txt
+++ b/irobot_create_gz/irobot_create_gz_plugins/Create3Hmi/CMakeLists.txt
@@ -6,7 +6,8 @@ endif()
 
 set(CMAKE_AUTOMOC ON)
 
-# Find Qt5
+find_package(gz_gui_vendor REQUIRED)
+find_package(gz-gui REQUIRED)
 find_package(Qt5
   COMPONENTS
     Core
@@ -14,8 +15,6 @@ find_package(Qt5
     QuickControls2
   REQUIRED
 )
-
-find_package(gz-gui8 REQUIRED)
 
 qt5_add_resources(resources_rcc Create3Hmi.qrc)
 
@@ -32,16 +31,17 @@ include_directories(
     ${Qt5Quick_INCLUDE_DIRS}
     ${Qt5QuickControls2_INCLUDE_DIRS}
 )
-target_link_libraries(
-  Create3Hmi
+target_link_libraries(Create3Hmi
+  PUBLIC
+    gz-gui::gz-gui
     ${Qt5Core_LIBRARIES}
     ${Qt5Qml_LIBRARIES}
     ${Qt5Quick_LIBRARIES}
     ${Qt5QuickControls2_LIBRARIES}
 )
-ament_target_dependencies(
-  Create3Hmi
-    gz-gui8
+ament_target_dependencies(Create3Hmi
+  gz_gui_vendor
+  gz-gui::gz-gui
 )
 
 install(


### PR DESCRIPTION
## Description

I was testing the use of upcoming Gazebo Ionic with current jazzy branch (it is using Gazebo Harmonic by default) and found that the use of the new vendor packages could be improved and corrected according to https://gazebosim.org/docs/ionic/ros2_gz_vendor_pkgs/#cmakelists-txt-for-building-with-gazebo-vendor-packages

I've also modernize the CMake a bit to solve problems with exporting the necessary linking.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

I test the compilation using Gazebo Ionic in a docker container. 

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation