### PR TITLE
Update pose_republisher_node.cpp

### DIFF
--- a/irobot_create_ignition/irobot_create_ignition_toolbox/src/pose_republisher/pose_republisher_node.cpp
+++ b/irobot_create_ignition/irobot_create_ignition_toolbox/src/pose_republisher/pose_republisher_node.cpp
@@ -104,8 +104,7 @@ void PoseRepublisher::robot_subscriber_callback(const tf2_msgs::msg::TFMessage::
       // Convert pose to tf2 transform
       tf2::convert(receiver_msg->pose.pose, receiver_pose);
       // Get receiver pose with respect to world frame
-      tf2::Transform receiver_world_pose = utils::static_link_wrt_global_frame(
-        receiver_pose, last_robot_pose_);
+      tf2::Transform receiver_world_pose = last_robot_pose_ * receiver_pose;
       // Convert tf2 transform back to pose
       utils::tf2_transform_to_pose(receiver_world_pose, receiver_msg->pose.pose);
       // Publish
@@ -130,8 +129,7 @@ void PoseRepublisher::dock_subscriber_callback(const tf2_msgs::msg::TFMessage::S
       // Convert pose to tf2 transform
       tf2::convert(emitter_msg->pose.pose, emitter_pose);
       // Get emitter pose with respect to world frame
-      tf2::Transform emitter_world_pose = utils::static_link_wrt_global_frame(
-        emitter_pose, last_dock_pose_);
+      tf2::Transform emitter_world_pose last_dock_pose_ * emitter_pose;
       // Convert tf2 transform back to pose
       utils::tf2_transform_to_pose(emitter_world_pose, emitter_msg->pose.pose);
       // Publish


### PR DESCRIPTION
`tf2::Transform receiver_world_pose = last_robot_pose_ * receiver_pose;` should be enough when transforming the receiver pose (in robot frame) into the world frame using the robot pose (in world frame). 

Similarly for emitter pose.

## Description

The function `inline tf2::Transform static_link_wrt_global_frame(tf2::Transform static_link, tf2::Transform base_frame)` in `irobot_create_ignition_toolbox/include/irobot_create_ignition_toolbox/utils.hpp` is not necessary and might be wrong. 

This is a simple change that addresses this mistake. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Changing the orientation of the ir opcode sensors with respect to the base frame results in wrong transforms due to the mistake in transforms mentioned above. This fix makes sure that the transforms are correct. I have tested this by adding a dummy base_link frame that is 180 off the original base_link frame. 

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
