### PR TITLE
Fix Typos and Update ROS 2 Jazzy Reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Have a look at the [Create® 3 documentation](https://iroboteducation.github.io/
 
 Required dependencies:
 
-1. [ROS 2 humble](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html)
+1. [ROS 2 Jazzy](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html)
 2. ROS 2 dev tools:
     - [colcon-common-extensions](https://pypi.org/project/colcon-common-extensions/)
     - [rosdep](https://pypi.org/project/rosdep/): Used to install dependencies when building from sources
@@ -37,7 +37,7 @@ mkdir -p ~/create3_ws/src
 ```
 
 - Clone this repository into the src directory from above.
-- Clone the []`irobot_create_msgs` repository](https://github.com/iRobotEducation/irobot_create_msgs) into the workspace
+- Clone the [`irobot_create_msgs` repository](https://github.com/iRobotEducation/irobot_create_msgs) into the workspace
 
 - Navigate to the workspace and install ROS 2 dependencies with:
 


### PR DESCRIPTION
## Description

This PR fixes minor typos and updates the ROS 2 version reference from Humble to Jazzy to match the jazzy branch.

Fixes #237 .

### Changes Made
- Replaced `ROS 2 Humble` with `ROS 2 Jazzy` in the Prerequisites section.
- Updated the link to the [ROS 2 Jazzy Installation Guide](https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html).
- Fixed broken markdown formatting in the `irobot_create_msgs` cloning instructions.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

No functional changes were made—only documentation updates. No additional testing required.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
