### PR TITLE
Update IR intensity sensor frame ID handling

### DIFF
--- a/irobot_create_ignition/irobot_create_ignition_bringup/worlds/maze.sdf
+++ b/irobot_create_ignition/irobot_create_ignition_bringup/worlds/maze.sdf
@@ -1,5 +1,5 @@
 <sdf version='1.8'>
-    <world name='default'>
+    <world name='maze'>
         <physics name='1ms' type='ignored'>
             <max_step_size>0.001</max_step_size>
             <real_time_factor>1</real_time_factor>

--- a/irobot_create_ignition/irobot_create_ignition_toolbox/src/sensors/ir_intensity.cpp
+++ b/irobot_create_ignition/irobot_create_ignition_toolbox/src/sensors/ir_intensity.cpp
@@ -71,8 +71,12 @@ void IrIntensity::ir_scan_callback(const sensor_msgs::msg::LaserScan::SharedPtr 
 
   // Publish to appropriate topic
   for (const std::string & sensor : ir_intensity_sensors_) {
-    if (ir_msg->header.frame_id.find(sensor) != std::string::npos) {
+    std::string expected_frame = "ir_intensity_" + sensor;
+    if (ir_msg->header.frame_id.rfind(expected_frame) != std::string::npos) {
+      ir_intensity_msg.header.frame_id = std::move(expected_frame);
+      ir_intensity_msg.header.stamp = ir_msg->header.stamp;
       ir_intensity_pub_[sensor]->publish(ir_intensity_msg);
+      break;
     }
   }
 }


### PR DESCRIPTION

## Description

The topic  /ir_intensity  publishes a vector containing a single intensity message instead of 7,  even though there are 7 IR sensors.
  
The node that publishes the intensity value of each IR sensor individually publishes the message
without a frame_id . Therefore, the readings from all IR sensors share the "same"  frame_id .
https://github.com/iRobotEducation/create3_sim/blob/6a8bc44f9be2c260bc17e753c31455d6759af238/irobot_create_ignition/irobot_create_ignition_toolbox/src/sensors/ir_intensity.cpp#L56-L77

Subsequently, the node that aggregates these individual intensity values into a vector stores them in a map using the  frame_id  as the key. Consequently, every time this node receives a new reading from any of the IR sensors, it overwrites the same position in the map. The vector publisher node then periodically iterates through this map, builds a vector from its contents (resulting in only one intensity message), and publishes it to  /ir_intensity .

https://github.com/iRobotEducation/create3_sim/blob/6a8bc44f9be2c260bc17e753c31455d6759af238/irobot_create_common/irobot_create_nodes/src/ir_intensity_vector_publisher.cpp#L54-L65

Fixes #209 
- The node publishing intensity values uses now frame_id according the TF tree. 

- Correct also the world name inside maze.sdf. **maze** instead of **default**. Otherwise /ir_intensity will not work with the world maze.
https://github.com/iRobotEducation/create3_sim/blob/6a8bc44f9be2c260bc17e753c31455d6759af238/irobot_create_ignition/irobot_create_ignition_bringup/worlds/maze.sdf#L2



## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tests were conducted by launching the simulation as described in the documentation, and the verification of IR intensity values was done using PlotJuggler to ensure the correct structure of the intensity vector and the correctness of the range values.

## Checklist

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] (no needed) I have made corresponding changes to the documentation
